### PR TITLE
fix: NavItem sibling route 오탐 수정 및 DarkModeToggle SSR 계약 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, dev]
-  push:
-    branches: [main, dev]
 
 jobs:
   ci:

--- a/components/Sidebar/NavItem.tsx
+++ b/components/Sidebar/NavItem.tsx
@@ -27,7 +27,8 @@ type NavItemProps = {
  */
 export const NavItem = ({ href, label, Icon }: NavItemProps) => {
   const pathname = usePathname();
-  const isActive = href === "/" ? pathname === "/" : pathname.startsWith(href);
+  const isActive =
+    href === "/" ? pathname === "/" : pathname === href || pathname.startsWith(`${href}/`);
 
   return (
     <StyledLink href={href} isActive={isActive} aria-current={isActive ? "page" : undefined}>

--- a/components/Sidebar/__tests__/DarkModeToggle.test.tsx
+++ b/components/Sidebar/__tests__/DarkModeToggle.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { THEME_DARK, THEME_LIGHT } from "@/constants/theme";
+import { THEME_COOKIE_KEY, THEME_DARK, THEME_LIGHT } from "@/constants/theme";
 
 import { DarkModeToggle } from "../DarkModeToggle";
 
@@ -13,7 +13,7 @@ describe("DarkModeToggle", () => {
 
   afterEach(() => {
     delete document.documentElement.dataset.theme;
-    document.cookie = "theme=; max-age=0";
+    document.cookie = `${THEME_COOKIE_KEY}=; max-age=0`;
   });
 
   it("Dark Mode 레이블을 렌더링한다", () => {
@@ -36,6 +36,7 @@ describe("DarkModeToggle", () => {
     render(<DarkModeToggle />);
     await userEvent.click(screen.getByRole("switch"));
     expect(document.documentElement.dataset.theme).toBe(THEME_DARK);
+    expect(document.cookie).toContain(`${THEME_COOKIE_KEY}=${THEME_DARK}`);
   });
 
   it("다크모드에서 토글 클릭 시 data-theme을 light로 변경한다", async () => {
@@ -43,5 +44,6 @@ describe("DarkModeToggle", () => {
     render(<DarkModeToggle isDarkMode={true} />);
     await userEvent.click(screen.getByRole("switch"));
     expect(document.documentElement.dataset.theme).toBe(THEME_LIGHT);
+    expect(document.cookie).toContain(`${THEME_COOKIE_KEY}=${THEME_LIGHT}`);
   });
 });

--- a/components/Sidebar/__tests__/DarkModeToggle.test.tsx
+++ b/components/Sidebar/__tests__/DarkModeToggle.test.tsx
@@ -13,7 +13,7 @@ describe("DarkModeToggle", () => {
 
   afterEach(() => {
     delete document.documentElement.dataset.theme;
-    document.cookie = `${THEME_COOKIE_KEY}=; max-age=0`;
+    document.cookie = `${THEME_COOKIE_KEY}=; path=/; max-age=0`;
   });
 
   it("Dark Mode 레이블을 렌더링한다", () => {

--- a/components/Sidebar/__tests__/NavItem.test.tsx
+++ b/components/Sidebar/__tests__/NavItem.test.tsx
@@ -56,4 +56,10 @@ describe("NavItem", () => {
     render(<NavItem href="/" label="Dashboard" Icon={MockIcon} />);
     expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
   });
+
+  it("sibling route(/notes-archive)에서 /notes 메뉴가 active 처리되지 않는다 (경계 없는 prefix 오탐 방지)", () => {
+    vi.mocked(usePathname).mockReturnValue("/notes-archive");
+    render(<NavItem href="/notes" label="Notes" Icon={MockIcon} />);
+    expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
+  });
 });


### PR DESCRIPTION
## 🍀 관련 이슈

close #6

<br /><br />

## 🍀 개요

> 이 PR에서 구현하거나 수정한 내용을 한 줄로 요약합니다.

PR #7 머지 이후 누락된 후속 커밋을 반영합니다.

<br /><br />

## 🍀 작업 내용

> 변경된 내용을 리스트 형태로 정리합니다.

- `NavItem` active 판별 버그 수정: `startsWith(href)` → `pathname === href || pathname.startsWith(\`${href}/\`)` (sibling route 오탐 방지)
- `NavItem.test.tsx`: `/notes-archive`에서 `/notes`가 비활성화되는 회귀 테스트 추가
- `DarkModeToggle.test.tsx`: 토글 시 `layout.tsx` SSR 테마 복원 계약을 쿠키 assertion으로 고정