### PR TITLE
PageHeader, CategoryFilter, SortSelect 컴포넌트 구현

### DIFF
--- a/app/links/new/page.tsx
+++ b/app/links/new/page.tsx
@@ -1,0 +1,10 @@
+/**
+ * 새 링크 추가 페이지
+ */
+export default function NewLinkPage() {
+  return (
+    <div>
+      <h1>New Link</h1>
+    </div>
+  );
+}

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -9,16 +9,25 @@ import {
 } from "@/constants/category";
 
 type LinksPageProps = {
-  searchParams: Promise<{ category?: string; sort?: string }>;
+  searchParams: Promise<{
+    category?: string | string[];
+    sort?: string | string[];
+  }>;
 };
 
 export default async function LinksPage({ searchParams }: LinksPageProps) {
   const { category, sort } = await searchParams;
 
+  // 배열로 전달된 경우 첫 번째 값만 사용
+  const rawCategory = Array.isArray(category) ? category[0] : category;
+  const rawSort = Array.isArray(sort) ? sort[0] : sort;
+
   // 유효하지 않은 값은 기본값으로 폴백
-  const selectedSort = isCategorySortValue(sort) ? sort : SORT_OPTIONS[0].value;
-  const selectedCategory = isCategory(category)
-    ? category
+  const selectedSort = isCategorySortValue(rawSort)
+    ? rawSort
+    : SORT_OPTIONS[0].value;
+  const selectedCategory = isCategory(rawCategory)
+    ? rawCategory
     : CATEGORIES[0].value;
 
   return (

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -1,0 +1,41 @@
+import { CategoryFilter } from "@/components/CategoryFilter";
+import { PageHeader } from "@/components/PageHeader";
+import { SortSelect } from "@/components/SortSelect";
+import {
+  CATEGORIES,
+  isCategory,
+  isCategorySortValue,
+  SORT_OPTIONS,
+} from "@/constants/category";
+
+type LinksPageProps = {
+  searchParams: Promise<{ category?: string; sort?: string }>;
+};
+
+export default async function LinksPage({ searchParams }: LinksPageProps) {
+  const { category, sort } = await searchParams;
+
+  // 유효하지 않은 값은 기본값으로 폴백
+  const selectedSort = isCategorySortValue(sort) ? sort : SORT_OPTIONS[0].value;
+  const selectedCategory = isCategory(category)
+    ? category
+    : CATEGORIES[0].value;
+
+  return (
+    <>
+      <PageHeader className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <PageHeader.Title>Links</PageHeader.Title>
+          <PageHeader.NewButton href="/links/new">
+            + New Link
+          </PageHeader.NewButton>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <CategoryFilter selected={selectedCategory} />
+          <SortSelect selected={selectedSort} />
+        </div>
+      </PageHeader>
+    </>
+  );
+}

--- a/app/notes/new/page.tsx
+++ b/app/notes/new/page.tsx
@@ -1,0 +1,10 @@
+/**
+ * 새 노트 추가 페이지
+ */
+export default function NewNotePage() {
+  return (
+    <div>
+      <h1>New Note</h1>
+    </div>
+  );
+}

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,0 +1,41 @@
+import { CategoryFilter } from "@/components/CategoryFilter";
+import { PageHeader } from "@/components/PageHeader";
+import { SortSelect } from "@/components/SortSelect";
+import {
+  CATEGORIES,
+  isCategory,
+  isCategorySortValue,
+  SORT_OPTIONS,
+} from "@/constants/category";
+
+type NotesPageProps = {
+  searchParams: Promise<{ category?: string; sort?: string }>;
+};
+
+export default async function NotesPage({ searchParams }: NotesPageProps) {
+  const { category, sort } = await searchParams;
+
+  // 유효하지 않은 값은 기본값으로 폴백
+  const selectedSort = isCategorySortValue(sort) ? sort : SORT_OPTIONS[0].value;
+  const selectedCategory = isCategory(category)
+    ? category
+    : CATEGORIES[0].value;
+
+  return (
+    <>
+      <PageHeader className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <PageHeader.Title>Notes</PageHeader.Title>
+          <PageHeader.NewButton href="/notes/new">
+            + New Note
+          </PageHeader.NewButton>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <CategoryFilter selected={selectedCategory} />
+          <SortSelect selected={selectedSort} />
+        </div>
+      </PageHeader>
+    </>
+  );
+}

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -9,16 +9,25 @@ import {
 } from "@/constants/category";
 
 type NotesPageProps = {
-  searchParams: Promise<{ category?: string; sort?: string }>;
+  searchParams: Promise<{
+    category?: string | string[];
+    sort?: string | string[];
+  }>;
 };
 
 export default async function NotesPage({ searchParams }: NotesPageProps) {
   const { category, sort } = await searchParams;
 
+  // 배열로 전달된 경우 첫 번째 값만 사용
+  const rawCategory = Array.isArray(category) ? category[0] : category;
+  const rawSort = Array.isArray(sort) ? sort[0] : sort;
+
   // 유효하지 않은 값은 기본값으로 폴백
-  const selectedSort = isCategorySortValue(sort) ? sort : SORT_OPTIONS[0].value;
-  const selectedCategory = isCategory(category)
-    ? category
+  const selectedSort = isCategorySortValue(rawSort)
+    ? rawSort
+    : SORT_OPTIONS[0].value;
+  const selectedCategory = isCategory(rawCategory)
+    ? rawCategory
     : CATEGORIES[0].value;
 
   return (

--- a/components/CategoryFilter.tsx
+++ b/components/CategoryFilter.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { CATEGORIES, Category } from "@/constants/category";
+import { cn } from "@/lib/cn";
+
+type CategoryFilterProps = {
+  /** 현재 선택된 카테고리 — Page의 searchParams에서 주입 */
+  selected: Category;
+};
+
+/**
+ * 카테고리 탭 필터 컴포넌트
+ *
+ * - 선택 상태는 URL searchParams(category)로 관리
+ * - 클릭 시 router.push로 URL 업데이트 → 페이지 서버 재렌더링
+ */
+export const CategoryFilter = ({ selected }: CategoryFilterProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  /**
+   * 카테고리 클릭 핸들러
+   * - URL searchParams(category) 업데이트 -> 페이지 서버 재렌더링
+   *
+   * @param category 선택된 카테고리 (Category)
+   */
+  const handleClick = (category: Category) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("category", category);
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {CATEGORIES.map(({ label, value }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => handleClick(value)}
+          className={cn(
+            "font-display rounded-xl px-3 py-1 text-sm font-medium transition-[background-color,color] duration-150",
+            value === selected
+              ? "bg-primary text-white"
+              : "bg-secondary text-foreground hover:bg-accent",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/components/CategoryFilter.tsx
+++ b/components/CategoryFilter.tsx
@@ -39,6 +39,7 @@ export const CategoryFilter = ({ selected }: CategoryFilterProps) => {
         <button
           key={value}
           type="button"
+          aria-pressed={value === selected}
           onClick={() => handleClick(value)}
           className={cn(
             "font-display rounded-xl px-3 py-1 text-sm font-medium transition-[background-color,color] duration-150",

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,6 +1,7 @@
 import { FC, SVGProps } from "react";
 
 import ChartSvg from "@/public/icons/chart.svg";
+import ChevronSvg from "@/public/icons/chevron.svg";
 import ClipSvg from "@/public/icons/clip.svg";
 import HomeSvg from "@/public/icons/home.svg";
 import LogoSvg from "@/public/icons/logo.svg";
@@ -31,3 +32,4 @@ export const NoteIcon = withSize(NoteSvg);
 export const ClipIcon = withSize(ClipSvg);
 export const SearchIcon = withSize(SearchSvg);
 export const ChartIcon = withSize(ChartSvg);
+export const ChevronIcon = withSize(ChevronSvg);

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -1,0 +1,59 @@
+import { PropsWithChildren, ReactNode } from "react";
+
+import Link from "next/link";
+
+import { cn } from "@/lib/cn";
+
+/**
+ * 페이지 제목 (h1)
+ */
+const Title = ({ children }: PropsWithChildren) => {
+  return <h1 className="text-foreground text-2xl font-bold">{children}</h1>;
+};
+
+type NewButtonProps = {
+  href: string;
+  children: ReactNode;
+};
+
+/**
+ * 새 항목 생성 링크 버튼
+ * - href: 이동할 경로
+ * - children: 버튼 내부 문구
+ */
+const NewButton = ({ href, children }: NewButtonProps) => {
+  return (
+    <Link
+      href={href}
+      className="bg-primary hover:bg-primary/90 font-display rounded-xl px-3 py-1.5 text-sm font-medium text-white transition-colors duration-150"
+    >
+      {children}
+    </Link>
+  );
+};
+
+type PageHeaderRootProps = PropsWithChildren<{ className?: string }>;
+
+/**
+ * 페이지 헤더 루트 컴포넌트
+ * - className: 추가 스타일 (기본 스타일에 병합됨)
+ */
+const PageHeaderRoot = ({ children, className }: PageHeaderRootProps) => {
+  return (
+    <header
+      className={cn("border-secondary bg-card border-b px-6 py-4", className)}
+    >
+      {children}
+    </header>
+  );
+};
+
+/**
+ * 페이지 헤더 컴포넌트
+ * - Title: 페이지 제목 (h1)
+ * - NewButton: 새 항목 생성 링크 버튼 (href, children 수신)
+ */
+export const PageHeader = Object.assign(PageHeaderRoot, {
+  Title,
+  NewButton,
+});

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChartIcon, ClipIcon, HomeIcon, LogoIcon, NoteIcon, SearchIcon } from "@/components/Icons";
+import {
+  ChartIcon,
+  ClipIcon,
+  HomeIcon,
+  LogoIcon,
+  NoteIcon,
+  SearchIcon,
+} from "@/components/Icons";
 
 import { DarkModeToggle } from "./DarkModeToggle";
 import { NavItem } from "./NavItem";
@@ -33,20 +40,24 @@ type SidebarProps = {
  * @param onLogout 로그아웃 핸들러 함수
  * @param isDarkMode 초기 다크 모드 상태 (SSR 렌더링 시 클로저로 사용)
  */
-export const Sidebar = ({ userName = "Loki", isDarkMode, onLogout = () => {} }: SidebarProps) => {
+export const Sidebar = ({
+  userName = "Loki",
+  isDarkMode,
+  onLogout = () => {},
+}: SidebarProps) => {
   return (
-    <aside className="flex w-65 min-h-screen shrink-0 flex-col gap-6 border-r border-secondary bg-card px-2 py-6 shadow-sm">
+    <aside className="border-secondary bg-card flex min-h-screen w-65 shrink-0 flex-col gap-6 border-r px-2 py-6 shadow-sm">
       {/* 로고 */}
       <div className="flex items-center gap-4 px-4 py-2">
-        <div className="flex aspect-square items-center justify-center rounded-lg bg-primary-light text-primary">
+        <div className="bg-primary-light text-primary flex aspect-square h-full items-center justify-center rounded-lg">
           <LogoIcon />
         </div>
 
         <div className="flex flex-col py-1">
-          <span className="text-base font-bold leading-tight text-foreground">
+          <span className="text-foreground text-base leading-tight font-bold">
             De Loki
           </span>
-          <span className="font-display text-xs text-muted-foreground">
+          <span className="font-display text-muted-foreground text-xs">
             지식 아카이브
           </span>
         </div>
@@ -60,11 +71,11 @@ export const Sidebar = ({ userName = "Loki", isDarkMode, onLogout = () => {} }: 
       </nav>
 
       {/* 하단 영역 */}
-      <div className="flex flex-col gap-2 border-t border-secondary pt-4">
+      <div className="border-secondary flex flex-col gap-2 border-t pt-4">
         <button
           type="button"
           onClick={onLogout}
-          className="px-4 py-1 text-left text-sm text-muted-foreground hover:text-foreground"
+          className="text-muted-foreground hover:text-foreground px-4 py-1 text-left text-sm"
         >
           Logout
         </button>

--- a/components/SortSelect.tsx
+++ b/components/SortSelect.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type { CategorySortValue } from "@/constants/category";
+import { SORT_OPTIONS } from "@/constants/category";
+import { cn } from "@/lib/cn";
+
+import { ChevronIcon } from "./Icons";
+
+type SortTriggerButtonProps = {
+  isOpen: boolean;
+  selectedLabel: string;
+  handleOpen: () => void;
+};
+
+/**
+ * 정렬 옵션 드롭다운을 여는 트리거 버튼 컴포넌트
+ *
+ * @param isOpen 드롭다운 열림 상태 (아이콘 회전 제어)
+ * @param selectedLabel 현재 선택된 정렬 옵션의 라벨 (버튼 텍스트)
+ * @param handleOpen 버튼 클릭 시 드롭다운 열기/닫기 핸들러
+ */
+const SortTriggerButton = ({
+  isOpen,
+  selectedLabel,
+  handleOpen,
+}: SortTriggerButtonProps) => {
+  return (
+    <button
+      type="button"
+      onClick={handleOpen}
+      className="bg-secondary text-foreground focus:outline-primary flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1 text-sm focus:outline-2 focus:outline-offset-2"
+    >
+      {selectedLabel}
+      <ChevronIcon
+        width={12}
+        height={12}
+        className={cn(
+          "text-muted-foreground transition-transform duration-200",
+          isOpen ? "rotate-180" : "rotate-0",
+        )}
+      />
+    </button>
+  );
+};
+
+type SortOptionsProps = {
+  isOpen: boolean;
+  selected: CategorySortValue;
+  handleSelect: (value: CategorySortValue) => void;
+};
+
+/**
+ * 정렬 옵션 드롭다운 컴포넌트
+ *
+ * @param isOpen 드롭다운 열림 상태
+ * @param selected 현재 선택된 정렬 옵션 값
+ * @param handleSelect 옵션 선택 핸들러
+ */
+const SortOptions = ({ isOpen, selected, handleSelect }: SortOptionsProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <ul className="bg-secondary absolute right-0 z-10 mt-1 min-w-full rounded-md shadow-md">
+      {SORT_OPTIONS.map(({ label, value }) => (
+        <li key={value}>
+          <button
+            type="button"
+            onClick={() => handleSelect(value)}
+            className={`text-foreground hover:bg-primary/10 focus-visible:ring-primary/30 w-full cursor-pointer px-3 py-1.5 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset ${
+              value === selected ? "text-primary font-medium" : ""
+            }`}
+          >
+            {label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+type SortSelectProps = {
+  selected: CategorySortValue;
+};
+
+/**
+ * 정렬 셀렉트 컴포넌트
+ * - 선택 상태는 URL searchParams(sort)로 관리
+ * - 변경 시 router.push로 URL 업데이트 -> 페이지 서버 재렌더링
+ */
+export const SortSelect = ({ selected }: SortSelectProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 현재 선택된 옵션의 라벨 (value -> label 매핑)
+  const selectedLabel =
+    SORT_OPTIONS.find((opt) => opt.value === selected)?.label ??
+    SORT_OPTIONS[0].label;
+
+  /**
+   * 정렬 옵션 선택 핸들러
+   * - URL searchParams(sort) 업데이트 -> 페이지 서버 재렌더링
+   *
+   * @param value 선택된 정렬 옵션 값 (CategorySortValue)
+   */
+  const handleSelect = (value: CategorySortValue) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("sort", value);
+    router.push(`${pathname}?${params.toString()}`);
+    setIsOpen(false);
+  };
+
+  /**
+   * 외부 클릭 시 드롭다운 닫기
+   */
+  useEffect(() => {
+    /**
+     * 컨테이너 외부 클릭 감지 핸들러
+     */
+    const handleClickOutside = (e: MouseEvent) => {
+      const container = containerRef.current;
+      const isOutside = container && !container.contains(e.target as Node);
+      if (isOutside) setIsOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="font-display flex items-center gap-2">
+      <span className="text-muted-foreground text-md">정렬:</span>
+      <div ref={containerRef} className="relative">
+        <SortTriggerButton
+          isOpen={isOpen}
+          selectedLabel={selectedLabel}
+          handleOpen={() => setIsOpen((prev) => !prev)}
+        />
+        <SortOptions
+          isOpen={isOpen}
+          selected={selected}
+          handleSelect={handleSelect}
+        />
+      </div>
+    </div>
+  );
+};

--- a/components/SortSelect.tsx
+++ b/components/SortSelect.tsx
@@ -10,6 +10,9 @@ import { cn } from "@/lib/cn";
 
 import { ChevronIcon } from "./Icons";
 
+// listbox id - SortTriggerButton과 SortOptions 연결에 사용
+const SORT_LISTBOX_ID = "sort-listbox";
+
 type SortTriggerButtonProps = {
   isOpen: boolean;
   selectedLabel: string;
@@ -31,6 +34,9 @@ const SortTriggerButton = ({
   return (
     <button
       type="button"
+      aria-expanded={isOpen}
+      aria-haspopup="listbox"
+      aria-controls={SORT_LISTBOX_ID}
       onClick={handleOpen}
       className="bg-secondary text-foreground focus:outline-primary flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1 text-sm focus:outline-2 focus:outline-offset-2"
     >
@@ -64,13 +70,19 @@ const SortOptions = ({ isOpen, selected, handleSelect }: SortOptionsProps) => {
   if (!isOpen) return null;
 
   return (
-    <ul className="bg-secondary absolute right-0 z-10 mt-1 min-w-full rounded-md shadow-md">
+    <ul
+      role="listbox"
+      id={SORT_LISTBOX_ID}
+      className="bg-secondary absolute right-0 z-10 mt-1 min-w-full rounded-md shadow-md"
+    >
       {SORT_OPTIONS.map(({ label, value }) => (
-        <li key={value}>
+        <li key={value} role="presentation">
           <button
             type="button"
+            role="option"
+            aria-selected={value === selected}
             onClick={() => handleSelect(value)}
-            className={`text-foreground hover:bg-primary/10 focus-visible:ring-primary/30 w-full cursor-pointer px-3 py-1.5 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset ${
+            className={`text-foreground hover:bg-primary/10 focus-visible:ring-primary/30 w-full cursor-pointer px-3 py-1.5 text-left text-sm transition-colors focus-visible:ring-1 focus-visible:outline-none focus-visible:ring-inset ${
               value === selected ? "text-primary font-medium" : ""
             }`}
           >
@@ -136,7 +148,13 @@ export const SortSelect = ({ selected }: SortSelectProps) => {
   return (
     <div className="font-display flex items-center gap-2">
       <span className="text-muted-foreground text-md">정렬:</span>
-      <div ref={containerRef} className="relative">
+      <div
+        ref={containerRef}
+        className="relative"
+        onKeyDown={(e) => {
+          if (e.key === "Escape") setIsOpen(false);
+        }}
+      >
         <SortTriggerButton
           isOpen={isOpen}
           selectedLabel={selectedLabel}

--- a/components/__tests__/CategoryFilter.test.tsx
+++ b/components/__tests__/CategoryFilter.test.tsx
@@ -30,19 +30,32 @@ describe("CategoryFilter", () => {
     });
   });
 
-  it("선택된 카테고리 버튼은 활성 스타일을 가진다", () => {
+  it("선택된 카테고리 버튼은 활성 스타일과 aria-pressed=true를 가진다", () => {
     render(<CategoryFilter selected="frontend" />);
 
     const activeButton = screen.getByRole("button", { name: "프론트엔드" });
     expect(activeButton).toHaveClass("bg-primary");
+    expect(activeButton).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("선택되지 않은 카테고리 버튼은 비활성 스타일을 가진다", () => {
+  it("선택되지 않은 카테고리 버튼은 비활성 스타일과 aria-pressed=false를 가진다", () => {
     render(<CategoryFilter selected="all" />);
 
     const inactiveButton = screen.getByRole("button", { name: "프론트엔드" });
     expect(inactiveButton).toHaveClass("bg-secondary");
     expect(inactiveButton).not.toHaveClass("bg-primary");
+    expect(inactiveButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("선택된 카테고리 버튼은 하나뿐이다", () => {
+    render(<CategoryFilter selected="backend" />);
+
+    const pressedButtons = screen
+      .getAllByRole("button")
+      .filter((btn) => btn.getAttribute("aria-pressed") === "true");
+
+    expect(pressedButtons).toHaveLength(1);
+    expect(pressedButtons[0]).toHaveAccessibleName("백엔드");
   });
 
   it("카테고리 클릭 시 URL searchParams를 업데이트한다", async () => {

--- a/components/__tests__/CategoryFilter.test.tsx
+++ b/components/__tests__/CategoryFilter.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CATEGORIES } from "@/constants/category";
+
+import { CategoryFilter } from "../CategoryFilter";
+
+const mockPush = vi.fn();
+const mockPathname = "/notes";
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe("CategoryFilter", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("모든 카테고리 버튼을 렌더링한다", () => {
+    render(<CategoryFilter selected="all" />);
+
+    CATEGORIES.forEach(({ label }) => {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    });
+  });
+
+  it("선택된 카테고리 버튼은 활성 스타일을 가진다", () => {
+    render(<CategoryFilter selected="frontend" />);
+
+    const activeButton = screen.getByRole("button", { name: "프론트엔드" });
+    expect(activeButton).toHaveClass("bg-primary");
+  });
+
+  it("선택되지 않은 카테고리 버튼은 비활성 스타일을 가진다", () => {
+    render(<CategoryFilter selected="all" />);
+
+    const inactiveButton = screen.getByRole("button", { name: "프론트엔드" });
+    expect(inactiveButton).toHaveClass("bg-secondary");
+    expect(inactiveButton).not.toHaveClass("bg-primary");
+  });
+
+  it("카테고리 클릭 시 URL searchParams를 업데이트한다", async () => {
+    render(<CategoryFilter selected="all" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "백엔드" }));
+
+    expect(mockPush).toHaveBeenCalledWith("/notes?category=backend");
+  });
+
+  it("기존 searchParams를 유지하며 category만 업데이트한다", async () => {
+    mockSearchParams = new URLSearchParams("sort=newest");
+    render(<CategoryFilter selected="all" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "CS" }));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining("category=cs"),
+    );
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining("sort=newest"),
+    );
+  });
+
+  it("이미 선택된 카테고리를 다시 클릭해도 router.push를 호출한다", async () => {
+    render(<CategoryFilter selected="frontend" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "프론트엔드" }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/__tests__/PageHeader.test.tsx
+++ b/components/__tests__/PageHeader.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageHeader } from "../PageHeader";
+
+describe("PageHeader", () => {
+  describe("Title", () => {
+    it("제목을 h1으로 렌더링한다", () => {
+      render(
+        <PageHeader>
+          <PageHeader.Title>Notes</PageHeader.Title>
+        </PageHeader>,
+      );
+
+      const heading = screen.getByRole("heading", { level: 1 });
+      expect(heading).toHaveTextContent("Notes");
+    });
+  });
+
+  describe("NewButton", () => {
+    it("href와 children을 받아 링크를 렌더링한다", () => {
+      render(
+        <PageHeader>
+          <PageHeader.Title>Notes</PageHeader.Title>
+          <PageHeader.NewButton href="/notes/new">+ New Note</PageHeader.NewButton>
+        </PageHeader>,
+      );
+
+      const link = screen.getByRole("link", { name: "+ New Note" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/notes/new");
+    });
+
+    it("서로 다른 href와 문구를 받아 렌더링한다", () => {
+      render(
+        <PageHeader>
+          <PageHeader.Title>Links</PageHeader.Title>
+          <PageHeader.NewButton href="/links/new">+ New Link</PageHeader.NewButton>
+        </PageHeader>,
+      );
+
+      const link = screen.getByRole("link", { name: "+ New Link" });
+      expect(link).toHaveAttribute("href", "/links/new");
+    });
+  });
+
+  describe("조합 케이스", () => {
+    it("Title + NewButton 조합 (Notes 페이지)", () => {
+      render(
+        <PageHeader>
+          <PageHeader.Title>Notes</PageHeader.Title>
+          <PageHeader.NewButton href="/notes/new">+ New Note</PageHeader.NewButton>
+        </PageHeader>,
+      );
+
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Notes");
+      expect(screen.getByRole("link", { name: "+ New Note" })).toBeInTheDocument();
+    });
+
+    it("Title만 있을 때 링크를 렌더링하지 않는다", () => {
+      render(
+        <PageHeader>
+          <PageHeader.Title>Search</PageHeader.Title>
+        </PageHeader>,
+      );
+
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("header 시맨틱 요소로 렌더링한다", () => {
+      const { container } = render(
+        <PageHeader>
+          <PageHeader.Title>Dashboard</PageHeader.Title>
+        </PageHeader>,
+      );
+
+      expect(container.querySelector("header")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/__tests__/SortSelect.test.tsx
+++ b/components/__tests__/SortSelect.test.tsx
@@ -40,7 +40,7 @@ describe("SortSelect", () => {
     it("드롭다운이 닫혀있으면 옵션 목록을 렌더링하지 않는다", () => {
       render(<SortSelect selected="newest" />);
 
-      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
     it("유효하지 않은 selected값이면 첫 번째 옵션 라벨을 표시한다", () => {
@@ -57,7 +57,7 @@ describe("SortSelect", () => {
 
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
 
-      expect(screen.getByRole("list")).toBeInTheDocument();
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
 
     it("드롭다운이 열리면 모든 정렬 옵션을 렌더링한다", async () => {
@@ -66,9 +66,7 @@ describe("SortSelect", () => {
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
 
       SORT_OPTIONS.forEach(({ label }) => {
-        expect(
-          screen.getAllByRole("button", { name: label }).length,
-        ).toBeGreaterThanOrEqual(1);
+        expect(screen.getByRole("option", { name: label })).toBeInTheDocument();
       });
     });
 
@@ -79,7 +77,7 @@ describe("SortSelect", () => {
       await userEvent.click(trigger);
       await userEvent.click(trigger);
 
-      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
     it("외부 클릭 시 드롭다운이 닫힌다", async () => {
@@ -91,10 +89,10 @@ describe("SortSelect", () => {
       );
 
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
-      expect(screen.getByRole("list")).toBeInTheDocument();
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole("button", { name: "외부버튼" }));
-      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
   });
 
@@ -103,7 +101,7 @@ describe("SortSelect", () => {
       render(<SortSelect selected="newest" />);
 
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
-      await userEvent.click(screen.getByRole("button", { name: "오래된순" }));
+      await userEvent.click(screen.getByRole("option", { name: "오래된순" }));
 
       expect(mockPush).toHaveBeenCalledWith("/notes?sort=oldest");
     });
@@ -112,9 +110,9 @@ describe("SortSelect", () => {
       render(<SortSelect selected="newest" />);
 
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
-      await userEvent.click(screen.getByRole("button", { name: "가나다순" }));
+      await userEvent.click(screen.getByRole("option", { name: "가나다순" }));
 
-      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
 
     it("기존 searchParams를 유지하며 sort만 업데이트한다", async () => {
@@ -122,7 +120,7 @@ describe("SortSelect", () => {
       render(<SortSelect selected="newest" />);
 
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
-      await userEvent.click(screen.getByRole("button", { name: "오래된순" }));
+      await userEvent.click(screen.getByRole("option", { name: "오래된순" }));
 
       expect(mockPush).toHaveBeenCalledWith(
         expect.stringContaining("sort=oldest"),
@@ -130,6 +128,67 @@ describe("SortSelect", () => {
       expect(mockPush).toHaveBeenCalledWith(
         expect.stringContaining("category=frontend"),
       );
+    });
+  });
+
+  describe("접근성", () => {
+    it("트리거 버튼의 aria-expanded 초기값은 false다", () => {
+      render(<SortSelect selected="newest" />);
+
+      expect(screen.getByRole("button", { name: /최신순/ })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+
+    it("드롭다운이 열리면 트리거 버튼의 aria-expanded가 true가 된다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+
+      expect(screen.getByRole("button", { name: /최신순/ })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    it("드롭다운이 열리면 listbox role을 가진 목록이 렌더링된다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("현재 선택된 옵션의 aria-selected는 true다", async () => {
+      render(<SortSelect selected="oldest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /오래된순/ }));
+
+      expect(
+        screen.getByRole("option", { name: "오래된순" }),
+      ).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("선택되지 않은 옵션의 aria-selected는 false다", async () => {
+      render(<SortSelect selected="oldest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /오래된순/ }));
+
+      expect(
+        screen.getByRole("option", { name: "최신순" }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("Escape 키 입력 시 드롭다운이 닫힌다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+      await userEvent.keyboard("{Escape}");
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
   });
 

--- a/components/__tests__/SortSelect.test.tsx
+++ b/components/__tests__/SortSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -191,6 +191,19 @@ describe("SortSelect", () => {
       await userEvent.keyboard("{Escape}");
 
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("Escape가 아닌 키 입력 시 드롭다운이 유지된다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      const trigger = screen.getByRole("button", { name: /최신순/ });
+
+      await userEvent.click(trigger);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+      fireEvent.keyDown(trigger, { key: "Tab" });
+
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
   });
 

--- a/components/__tests__/SortSelect.test.tsx
+++ b/components/__tests__/SortSelect.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SORT_OPTIONS } from "@/constants/category";
+
+import { SortSelect } from "../SortSelect";
+
+const mockPush = vi.fn();
+const mockPathname = "/notes";
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("../Icons", () => ({
+  ChevronIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="chevron-icon" className={className} />
+  ),
+}));
+
+describe("SortSelect", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  describe("초기 렌더링", () => {
+    it("선택된 정렬 옵션의 라벨을 트리거 버튼에 표시한다", () => {
+      render(<SortSelect selected="newest" />);
+
+      expect(
+        screen.getByRole("button", { name: /최신순/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("드롭다운이 닫혀있으면 옵션 목록을 렌더링하지 않는다", () => {
+      render(<SortSelect selected="newest" />);
+
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+
+    it("유효하지 않은 selected값이면 첫 번째 옵션 라벨을 표시한다", () => {
+      // @ts-expect-error 유효하지 않은 값 테스트
+      render(<SortSelect selected="invalid" />);
+
+      expect(screen.getByText(SORT_OPTIONS[0].label)).toBeInTheDocument();
+    });
+  });
+
+  describe("드롭다운 열기/닫기", () => {
+    it("트리거 버튼 클릭 시 드롭다운이 열린다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+
+      expect(screen.getByRole("list")).toBeInTheDocument();
+    });
+
+    it("드롭다운이 열리면 모든 정렬 옵션을 렌더링한다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+
+      SORT_OPTIONS.forEach(({ label }) => {
+        expect(
+          screen.getAllByRole("button", { name: label }).length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it("트리거 버튼 재클릭 시 드롭다운이 닫힌다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      const trigger = screen.getByRole("button", { name: /최신순/ });
+      await userEvent.click(trigger);
+      await userEvent.click(trigger);
+
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+
+    it("외부 클릭 시 드롭다운이 닫힌다", async () => {
+      render(
+        <div>
+          <button>외부버튼</button>
+          <SortSelect selected="newest" />
+        </div>,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+      expect(screen.getByRole("list")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: "외부버튼" }));
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("옵션 선택", () => {
+    it("옵션 클릭 시 URL searchParams(sort)를 업데이트한다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+      await userEvent.click(screen.getByRole("button", { name: "오래된순" }));
+
+      expect(mockPush).toHaveBeenCalledWith("/notes?sort=oldest");
+    });
+
+    it("옵션 선택 후 드롭다운이 닫힌다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+      await userEvent.click(screen.getByRole("button", { name: "가나다순" }));
+
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+
+    it("기존 searchParams를 유지하며 sort만 업데이트한다", async () => {
+      mockSearchParams = new URLSearchParams("category=frontend");
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+      await userEvent.click(screen.getByRole("button", { name: "오래된순" }));
+
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("sort=oldest"),
+      );
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("category=frontend"),
+      );
+    });
+  });
+
+  describe("ChevronIcon 회전", () => {
+    it("드롭다운이 닫혀있으면 chevron이 rotate-0이다", () => {
+      render(<SortSelect selected="newest" />);
+
+      expect(screen.getByTestId("chevron-icon")).toHaveClass("rotate-0");
+    });
+
+    it("드롭다운이 열리면 chevron이 rotate-180이다", async () => {
+      render(<SortSelect selected="newest" />);
+
+      await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
+
+      expect(screen.getByTestId("chevron-icon")).toHaveClass("rotate-180");
+    });
+  });
+});

--- a/components/__tests__/SortSelect.test.tsx
+++ b/components/__tests__/SortSelect.test.tsx
@@ -122,12 +122,12 @@ describe("SortSelect", () => {
       await userEvent.click(screen.getByRole("button", { name: /최신순/ }));
       await userEvent.click(screen.getByRole("option", { name: "오래된순" }));
 
-      expect(mockPush).toHaveBeenCalledWith(
-        expect.stringContaining("sort=oldest"),
-      );
-      expect(mockPush).toHaveBeenCalledWith(
-        expect.stringContaining("category=frontend"),
-      );
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const pushedUrl = mockPush.mock.calls[0][0] as string;
+      const query = pushedUrl.split("?")[1] ?? "";
+      const params = new URLSearchParams(query);
+      expect(params.get("sort")).toBe("oldest");
+      expect(params.get("category")).toBe("frontend");
     });
   });
 
@@ -165,9 +165,10 @@ describe("SortSelect", () => {
 
       await userEvent.click(screen.getByRole("button", { name: /오래된순/ }));
 
-      expect(
-        screen.getByRole("option", { name: "오래된순" }),
-      ).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("option", { name: "오래된순" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
     });
 
     it("선택되지 않은 옵션의 aria-selected는 false다", async () => {
@@ -175,9 +176,10 @@ describe("SortSelect", () => {
 
       await userEvent.click(screen.getByRole("button", { name: /오래된순/ }));
 
-      expect(
-        screen.getByRole("option", { name: "최신순" }),
-      ).toHaveAttribute("aria-selected", "false");
+      expect(screen.getByRole("option", { name: "최신순" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
     });
 
     it("Escape 키 입력 시 드롭다운이 닫힌다", async () => {

--- a/constants/category.ts
+++ b/constants/category.ts
@@ -1,0 +1,42 @@
+/**
+ * 카테고리 상수
+ * - label: UI 표시용 한글
+ * - value: URL/서버 통신용 영문 식별자
+ */
+export const CATEGORIES = [
+  { label: "전체", value: "all" },
+  { label: "프론트엔드", value: "frontend" },
+  { label: "백엔드", value: "backend" },
+  { label: "DevOps", value: "devops" },
+  { label: "CS", value: "cs" },
+] as const;
+
+export type Category = (typeof CATEGORIES)[number]["value"];
+
+/**
+ * 값이 유효한 카테고리인지 검사하는 타입 가드 함수
+ */
+export const isCategory = (value: unknown): value is Category => {
+  return CATEGORIES.some((c) => c.value === value);
+};
+
+/**
+ * 정렬 옵션 상수
+ */
+export const SORT_OPTIONS = [
+  { label: "최신순", value: "newest" },
+  { label: "오래된순", value: "oldest" },
+  { label: "가나다순", value: "alphabetical" },
+] as const;
+
+export type CategorySortOption = (typeof SORT_OPTIONS)[number];
+export type CategorySortValue = CategorySortOption["value"];
+
+/**
+ * 값이 유효한 정렬 옵션 값인지 검사하는 타입 가드 함수
+ */
+export const isCategorySortValue = (
+  value: unknown,
+): value is CategorySortValue => {
+  return SORT_OPTIONS.some((option) => option.value === value);
+};

--- a/public/icons/chevron.svg
+++ b/public/icons/chevron.svg
@@ -1,0 +1,3 @@
+<svg width="current" height="current" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 4L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+</svg>


### PR DESCRIPTION
## 🍀 관련 이슈

close #9

<br /><br />

## 🍀 개요

> 이 PR에서 구현하거나 수정한 내용을 한 줄로 요약합니다.

PageHeader compound 컴포넌트 및 CategoryFilter, SortSelect 구현

<br /><br />

## 🍀 작업 내용

> 변경된 내용을 리스트 형태로 정리합니다.

- `PageHeader` compound 컴포넌트 구현 (Title, NewButton 서브컴포넌트)
- `CategoryFilter` 구현 - URL searchParams(category) 기반 선택 상태 관리
- `SortSelect` 드롭다운 구현 - URL searchParams(sort) 기반, 외부 클릭 닫기 처리
- `constants/category.ts` 카테고리/정렬 상수 및 타입 가드 추가
- `ChevronIcon` 추가 (chevron.svg + Icons.tsx)
- links/notes 페이지에 PageHeader, CategoryFilter, SortSelect 적용
- 각 컴포넌트 단위테스트 추가

<br /><br />

## 🍀 스크린샷

> UI 변경이 있는 경우 첨부합니다.

<img width="987" height="171" alt="스크린샷 2026-03-30 오전 1 28 02" src="https://github.com/user-attachments/assets/cd0743d1-932f-4935-8af6-63f6c394b713" />
