### PR TITLE
노트 목록 페이지 UI 구현 (페이지네이션, 필터, 정렬)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,7 +66,7 @@ export default async function RootLayout({
       <body className="bg-background text-foreground flex h-screen flex-col overflow-hidden font-sans antialiased">
         <div className="flex h-full overflow-hidden">
           <Sidebar isDarkMode={isDarkMode} />
-          <main className="flex-1 overflow-hidden">{children}</main>
+          <main className="flex flex-1 flex-col overflow-hidden">{children}</main>
         </div>
       </body>
     </html>

--- a/app/notes/[page]/page.tsx
+++ b/app/notes/[page]/page.tsx
@@ -36,12 +36,12 @@ export default async function NotesPage({
   const { page: pageParam } = await params;
   const { category, sort } = await searchParams;
 
-  const currentPage = parseInt(pageParam, 10);
+  // 페이지 번호는 순수 정수 문자열("1", "123" 등)만 허용
+  if (!/^\d+$/.test(pageParam)) notFound();
 
-  // 숫자가 아니거나 1 미만이면 404
-  if (isNaN(currentPage) || currentPage < 1) {
-    notFound();
-  }
+  // 페이지 번호가 1 미만이면 404
+  const currentPage = Number(pageParam);
+  if (currentPage < 1) notFound();
 
   // 배열로 전달된 경우 첫 번째 값만 사용
   const rawCategory = Array.isArray(category) ? category[0] : category;

--- a/app/notes/[page]/page.tsx
+++ b/app/notes/[page]/page.tsx
@@ -1,0 +1,95 @@
+import { notFound } from "next/navigation";
+
+import { NoteCardList } from "@/features/note/components/NoteCardList";
+import { getNotes } from "@/features/note/lib/getNotes";
+import { CategoryFilter } from "@/shared/components/CategoryFilter";
+import { PageHeader } from "@/shared/components/PageHeader";
+import { Pagination } from "@/shared/components/Pagination";
+import { SortSelect } from "@/shared/components/SortSelect";
+import {
+  CATEGORIES,
+  isCategory,
+  isCategorySortValue,
+  SORT_OPTIONS,
+} from "@/shared/constants/category";
+
+type NotesPageProps = {
+  params: Promise<{ page: string }>;
+  searchParams: Promise<{
+    category?: string | string[];
+    sort?: string | string[];
+  }>;
+};
+
+/**
+ * 노트 목록 동적 페이지
+ *
+ * - path param `[page]`: 현재 페이지 번호
+ * - searchParams: 카테고리 필터, 정렬 옵션 유지
+ * - 데이터 조회는 getNotes에 위임 (DB 전환 시 getNotes만 수정)
+ * - 유효하지 않은 page는 404 처리
+ */
+export default async function NotesPage({
+  params,
+  searchParams,
+}: NotesPageProps) {
+  const { page: pageParam } = await params;
+  const { category, sort } = await searchParams;
+
+  const currentPage = parseInt(pageParam, 10);
+
+  // 숫자가 아니거나 1 미만이면 404
+  if (isNaN(currentPage) || currentPage < 1) {
+    notFound();
+  }
+
+  // 배열로 전달된 경우 첫 번째 값만 사용
+  const rawCategory = Array.isArray(category) ? category[0] : category;
+  const selectedCategory = isCategory(rawCategory)
+    ? rawCategory
+    : CATEGORIES[0].value;
+
+  // 배열로 전달된 경우 첫 번째 값만 사용
+  const rawSort = Array.isArray(sort) ? sort[0] : sort;
+  const selectedSort = isCategorySortValue(rawSort)
+    ? rawSort
+    : SORT_OPTIONS[0].value;
+
+  // DB에서 노트 목록과 전체 페이지 수 조회
+  const { notes, totalPages } = await getNotes({
+    category: selectedCategory,
+    sort: selectedSort,
+    page: currentPage,
+  });
+
+  if (currentPage > totalPages) notFound();
+
+  return (
+    <>
+      <PageHeader className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <PageHeader.Title>Notes</PageHeader.Title>
+          <PageHeader.NewButton href="/notes/new">
+            + New Note
+          </PageHeader.NewButton>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <CategoryFilter selected={selectedCategory} />
+          <SortSelect selected={selectedSort} />
+        </div>
+      </PageHeader>
+
+      <div className="flex flex-1 flex-col p-6">
+        <NoteCardList notes={notes} />
+        <div className="mt-auto pt-6">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            basePath="/notes"
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,50 +1,11 @@
-import { CategoryFilter } from "@/shared/components/CategoryFilter";
-import { PageHeader } from "@/shared/components/PageHeader";
-import { SortSelect } from "@/shared/components/SortSelect";
-import {
-  CATEGORIES,
-  isCategory,
-  isCategorySortValue,
-  SORT_OPTIONS,
-} from "@/shared/constants/category";
+import { redirect } from "next/navigation";
 
-type NotesPageProps = {
-  searchParams: Promise<{
-    category?: string | string[];
-    sort?: string | string[];
-  }>;
-};
-
-export default async function NotesPage({ searchParams }: NotesPageProps) {
-  const { category, sort } = await searchParams;
-
-  // 배열로 전달된 경우 첫 번째 값만 사용
-  const rawCategory = Array.isArray(category) ? category[0] : category;
-  const rawSort = Array.isArray(sort) ? sort[0] : sort;
-
-  // 유효하지 않은 값은 기본값으로 폴백
-  const selectedSort = isCategorySortValue(rawSort)
-    ? rawSort
-    : SORT_OPTIONS[0].value;
-  const selectedCategory = isCategory(rawCategory)
-    ? rawCategory
-    : CATEGORIES[0].value;
-
-  return (
-    <>
-      <PageHeader className="flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-4">
-          <PageHeader.Title>Notes</PageHeader.Title>
-          <PageHeader.NewButton href="/notes/new">
-            + New Note
-          </PageHeader.NewButton>
-        </div>
-
-        <div className="flex items-center justify-between gap-4">
-          <CategoryFilter selected={selectedCategory} />
-          <SortSelect selected={selectedSort} />
-        </div>
-      </PageHeader>
-    </>
-  );
+/**
+ * /notes 기본 경로 → /notes/1 로 리다이렉트
+ *
+ * - 페이지네이션은 path param([page]) 기반으로 동작
+ * - searchParams(category, sort)는 없으면 [page] 페이지에서 기본값으로 처리
+ */
+export default async function NotesIndexPage() {
+  redirect("/notes/1");
 }

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,11 +1,27 @@
 import { redirect } from "next/navigation";
 
+type NotesIndexPageProps = {
+  searchParams: Promise<{ category?: string; sort?: string }>;
+};
+
 /**
  * /notes 기본 경로 → /notes/1 로 리다이렉트
  *
  * - 페이지네이션은 path param([page]) 기반으로 동작
  * - searchParams(category, sort)는 없으면 [page] 페이지에서 기본값으로 처리
  */
-export default async function NotesIndexPage() {
-  redirect("/notes/1");
+export default async function NotesIndexPage({
+  searchParams,
+}: NotesIndexPageProps) {
+  const params = await searchParams;
+
+  // searchParams에서 undefined인 값은 쿼리에서 제외
+  const queryString = new URLSearchParams(
+    Object.entries(params).filter(([, v]) => v !== undefined) as [
+      string,
+      string,
+    ][],
+  ).toString();
+
+  redirect(queryString ? `/notes/1?${queryString}` : "/notes/1");
 }

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,7 +1,10 @@
 import { redirect } from "next/navigation";
 
 type NotesIndexPageProps = {
-  searchParams: Promise<{ category?: string; sort?: string }>;
+  searchParams: Promise<{
+    category?: string | string[];
+    sort?: string | string[];
+  }>;
 };
 
 /**
@@ -14,13 +17,18 @@ export default async function NotesIndexPage({
   searchParams,
 }: NotesIndexPageProps) {
   const params = await searchParams;
+  const normalizedParams = {
+    category: Array.isArray(params.category)
+      ? params.category[0]
+      : params.category,
+    sort: Array.isArray(params.sort) ? params.sort[0] : params.sort,
+  };
 
   // searchParams에서 undefined인 값은 쿼리에서 제외
   const queryString = new URLSearchParams(
-    Object.entries(params).filter(([, v]) => v !== undefined) as [
-      string,
-      string,
-    ][],
+    Object.entries(normalizedParams).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
   ).toString();
 
   redirect(queryString ? `/notes/1?${queryString}` : "/notes/1");

--- a/features/note/__tests__/NoteCardList.test.tsx
+++ b/features/note/__tests__/NoteCardList.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { NoteListItem } from "@/shared/types/note";
+
+import { NoteCardList } from "../components/NoteCardList";
+
+/** 테스트용 노트 아이템 생성 헬퍼 */
+const makeNote = (overrides: Partial<NoteListItem> = {}): NoteListItem => ({
+  id: "note-1",
+  title: "테스트 노트",
+  category: "frontend",
+  tags: [],
+  createdAt: "2024.01.01",
+  ...overrides,
+});
+
+describe("NoteCardList", () => {
+  describe("빈 상태", () => {
+    it('notes가 빈 배열이면 "노트가 없습니다." 메시지를 렌더링한다', () => {
+      render(<NoteCardList notes={[]} />);
+
+      expect(screen.getByText("노트가 없습니다.")).toBeInTheDocument();
+    });
+
+    it("notes가 빈 배열이면 카드 링크를 렌더링하지 않는다", () => {
+      render(<NoteCardList notes={[]} />);
+
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("노트 목록 렌더링", () => {
+    it("notes 개수만큼 카드 링크를 렌더링한다", () => {
+      const notes = [
+        makeNote({ id: "1", title: "노트 A" }),
+        makeNote({ id: "2", title: "노트 B" }),
+        makeNote({ id: "3", title: "노트 C" }),
+      ];
+      render(<NoteCardList notes={notes} />);
+
+      expect(screen.getAllByRole("link")).toHaveLength(3);
+    });
+
+    it("노트 제목을 렌더링한다", () => {
+      const notes = [makeNote({ title: "React Hooks 정리" })];
+      render(<NoteCardList notes={notes} />);
+
+      expect(screen.getByText("React Hooks 정리")).toBeInTheDocument();
+    });
+
+    it("카드 링크의 href가 /notes/detail/[id]다", () => {
+      const notes = [makeNote({ id: "abc-123" })];
+      render(<NoteCardList notes={notes} />);
+
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        "/notes/detail/abc-123",
+      );
+    });
+
+    it("생성일을 time 엘리먼트로 렌더링한다", () => {
+      const notes = [makeNote({ createdAt: "2024.03.15" })];
+      render(<NoteCardList notes={notes} />);
+
+      const time = screen.getByText("2024.03.15");
+      expect(time.tagName.toLowerCase()).toBe("time");
+      expect(time).toHaveAttribute("dateTime", "2024.03.15");
+    });
+  });
+
+  describe("태그 렌더링", () => {
+    it("노트에 태그가 있으면 # 기호와 함께 렌더링한다", () => {
+      const notes = [
+        makeNote({
+          tags: [
+            { name: "react", color: "blue" },
+            { name: "typescript", color: "green" },
+          ],
+        }),
+      ];
+      render(<NoteCardList notes={notes} />);
+
+      expect(screen.getByText("#react")).toBeInTheDocument();
+      expect(screen.getByText("#typescript")).toBeInTheDocument();
+    });
+
+    it("태그가 없으면 태그 영역이 비어있다", () => {
+      const notes = [makeNote({ tags: [] })];
+      render(<NoteCardList notes={notes} />);
+
+      // # 으로 시작하는 텍스트가 없어야 함
+      const tagTexts = screen
+        .queryAllByText(/^#/)
+        .filter((el) => el.tagName !== "BODY");
+      expect(tagTexts).toHaveLength(0);
+    });
+  });
+
+  describe("여러 노트", () => {
+    it("각 카드의 제목이 모두 노출된다", () => {
+      const titles = ["노트 첫 번째", "노트 두 번째", "노트 세 번째"];
+      const notes = titles.map((title, i) =>
+        makeNote({ id: String(i), title }),
+      );
+      render(<NoteCardList notes={notes} />);
+
+      titles.forEach((title) => {
+        expect(screen.getByText(title)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/features/note/__tests__/NoteCardList.test.tsx
+++ b/features/note/__tests__/NoteCardList.test.tsx
@@ -65,7 +65,7 @@ describe("NoteCardList", () => {
 
       const time = screen.getByText("2024.03.15");
       expect(time.tagName.toLowerCase()).toBe("time");
-      expect(time).toHaveAttribute("dateTime", "2024.03.15");
+      expect(time).toHaveAttribute("dateTime", "2024-03-15");
     });
   });
 

--- a/features/note/__tests__/paginateNotes.test.ts
+++ b/features/note/__tests__/paginateNotes.test.ts
@@ -5,7 +5,7 @@ import type { NoteListItem } from "@/shared/types/note";
 
 import { paginateNotes } from "../lib/paginateNotes";
 
-/** 테스트용 노트 목목 생성 헬퍼 */
+/** 테스트용 노트 목록 생성 헬퍼 */
 const makeNotes = (count: number): NoteListItem[] =>
   Array.from({ length: count }, (_, i) => ({
     id: `note-${i + 1}`,
@@ -29,7 +29,7 @@ describe("paginateNotes", () => {
     });
 
     it("특정 category만 필터링한다", () => {
-      const notes = makeNotes(6); // frontend: 0,2,4 / backend: 1,3,5
+      const notes = makeNotes(6);
       const { paginated } = paginateNotes({
         notes,
         category: "frontend",

--- a/features/note/__tests__/paginateNotes.test.ts
+++ b/features/note/__tests__/paginateNotes.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { NOTES_PER_PAGE } from "@/shared/constants/pagination";
+import type { NoteListItem } from "@/shared/types/note";
+
+import { paginateNotes } from "../lib/paginateNotes";
+
+/** 테스트용 노트 목목 생성 헬퍼 */
+const makeNotes = (count: number): NoteListItem[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `note-${i + 1}`,
+    title: `Note ${String(i + 1).padStart(2, "0")}`,
+    category: i % 2 === 0 ? "frontend" : "backend",
+    tags: [],
+    createdAt: `2024.01.${String(i + 1).padStart(2, "0")}`,
+  }));
+
+describe("paginateNotes", () => {
+  describe("필터링", () => {
+    it('category가 "all"이면 전체 노트를 반환한다', () => {
+      const notes = makeNotes(5);
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "newest",
+        page: 1,
+      });
+      expect(paginated).toHaveLength(5);
+    });
+
+    it("특정 category만 필터링한다", () => {
+      const notes = makeNotes(6); // frontend: 0,2,4 / backend: 1,3,5
+      const { paginated } = paginateNotes({
+        notes,
+        category: "frontend",
+        sort: "newest",
+        page: 1,
+      });
+      expect(paginated.every((n) => n.category === "frontend")).toBe(true);
+      expect(paginated).toHaveLength(3);
+    });
+  });
+
+  describe("정렬", () => {
+    it('"newest" 정렬 시 createdAt 내림차순으로 반환한다', () => {
+      const notes = makeNotes(3);
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "newest",
+        page: 1,
+      });
+      expect(paginated[0].createdAt >= paginated[1].createdAt).toBe(true);
+      expect(paginated[1].createdAt >= paginated[2].createdAt).toBe(true);
+    });
+
+    it('"oldest" 정렬 시 createdAt 오름차순으로 반환한다', () => {
+      const notes = makeNotes(3);
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "oldest",
+        page: 1,
+      });
+      expect(paginated[0].createdAt <= paginated[1].createdAt).toBe(true);
+      expect(paginated[1].createdAt <= paginated[2].createdAt).toBe(true);
+    });
+
+    it('"alphabetical" 정렬 시 title 가나다순으로 반환한다', () => {
+      const notes: NoteListItem[] = [
+        {
+          id: "1",
+          title: "다 노트",
+          category: "frontend",
+          tags: [],
+          createdAt: "2024.01.01",
+        },
+        {
+          id: "2",
+          title: "가 노트",
+          category: "frontend",
+          tags: [],
+          createdAt: "2024.01.02",
+        },
+        {
+          id: "3",
+          title: "나 노트",
+          category: "frontend",
+          tags: [],
+          createdAt: "2024.01.03",
+        },
+      ];
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "alphabetical",
+        page: 1,
+      });
+      expect(paginated.map((n) => n.title)).toEqual([
+        "가 노트",
+        "나 노트",
+        "다 노트",
+      ]);
+    });
+  });
+
+  describe("페이지네이션", () => {
+    it("totalPages는 Math.ceil(filtered / NOTES_PER_PAGE)로 계산된다", () => {
+      const notes = makeNotes(NOTES_PER_PAGE + 1);
+      const { totalPages } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "newest",
+        page: 1,
+      });
+      expect(totalPages).toBe(2);
+    });
+
+    it("노트가 없어도 totalPages는 최소 1을 반환한다", () => {
+      const { totalPages } = paginateNotes({
+        notes: [],
+        category: "all",
+        sort: "newest",
+        page: 1,
+      });
+      expect(totalPages).toBe(1);
+    });
+
+    it("1페이지는 처음 NOTES_PER_PAGE개를 반환한다", () => {
+      const notes = makeNotes(NOTES_PER_PAGE * 2);
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "oldest",
+        page: 1,
+      });
+      expect(paginated).toHaveLength(NOTES_PER_PAGE);
+    });
+
+    it("마지막 페이지는 나머지 노트만 반환한다", () => {
+      const remainder = 3;
+      const notes = makeNotes(NOTES_PER_PAGE + remainder);
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "oldest",
+        page: 2,
+      });
+      expect(paginated).toHaveLength(remainder);
+    });
+
+    it("범위를 벗어난 page는 빈 배열을 반환한다", () => {
+      const notes = makeNotes(5);
+      const { paginated } = paginateNotes({
+        notes,
+        category: "all",
+        sort: "newest",
+        page: 99,
+      });
+      expect(paginated).toHaveLength(0);
+    });
+  });
+});

--- a/features/note/__tests__/toISODate.test.ts
+++ b/features/note/__tests__/toISODate.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { toISODate } from "../lib/toISODate";
+
+describe("toISODate", () => {
+  describe("정상 변환", () => {
+    it("YYYY.MM.DD 형식을 YYYY-MM-DD로 변환한다", () => {
+      expect(toISODate("2024.03.15")).toBe("2024-03-15");
+    });
+
+    it("월/일이 한 자리인 경우에도 패딩을 유지한다", () => {
+      expect(toISODate("2024.01.01")).toBe("2024-01-01");
+    });
+
+    it("연말 날짜를 올바르게 변환한다", () => {
+      expect(toISODate("2024.12.31")).toBe("2024-12-31");
+    });
+
+    it("윤년 2월 29일을 올바르게 변환한다", () => {
+      expect(toISODate("2024.02.29")).toBe("2024-02-29");
+    });
+  });
+
+  describe("형식 오류", () => {
+    it("YYYY-MM-DD 형식(하이픈)은 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024-03-15")).toThrow("YYYY.MM.DD 형식이 아닙니다");
+    });
+
+    it("날짜 없이 연월만 있으면 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024.03")).toThrow("YYYY.MM.DD 형식이 아닙니다");
+    });
+
+    it("빈 문자열은 오류를 발생시킨다", () => {
+      expect(() => toISODate("")).toThrow("YYYY.MM.DD 형식이 아닙니다");
+    });
+
+    it("문자가 포함된 경우 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024.월.15")).toThrow("YYYY.MM.DD 형식이 아닙니다");
+    });
+  });
+
+  describe("유효하지 않은 날짜", () => {
+    it("존재하지 않는 달(13월)은 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024.13.01")).toThrow("유효하지 않은 날짜입니다");
+    });
+
+    it("00월은 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024.00.01")).toThrow("유효하지 않은 날짜입니다");
+    });
+
+    it("00일은 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024.03.00")).toThrow("유효하지 않은 날짜입니다");
+    });
+
+    it("존재하지 않는 날(4월 31일)은 오류를 발생시킨다", () => {
+      expect(() => toISODate("2024.04.31")).toThrow("유효하지 않은 날짜입니다");
+    });
+
+    it("윤년이 아닌 해의 2월 29일은 오류를 발생시킨다", () => {
+      expect(() => toISODate("2023.02.29")).toThrow("유효하지 않은 날짜입니다");
+    });
+  });
+});

--- a/features/note/components/NoteCardList.tsx
+++ b/features/note/components/NoteCardList.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+
+import { NoteTag } from "@/shared/components/NoteTag";
+import type { NoteListItem } from "@/shared/types/note";
+
+type NoteCardProps = {
+  note: NoteListItem;
+};
+
+/**
+ * 노트 목록 카드 컴포넌트
+ * - 제목, 태그, 생성일을 표시
+ * - 카드 전체가 링크로 동작 (`/notes/detail/[id]`)
+ * - 태그는 NoteTag 공통 컴포넌트로 렌더링
+ *
+ * @param note 렌더링할 노트 데이터 (id, title, tags, createdAt 포함)
+ */
+const NoteCard = ({ note }: NoteCardProps) => {
+  return (
+    <Link
+      href={`/notes/detail/${note.id}`}
+      className="bg-card font-display border-secondary flex flex-col gap-6 rounded-xl border p-5 transition-shadow duration-200 hover:shadow-md"
+    >
+      <h2 className="text-foreground line-clamp-2 text-base leading-snug font-medium">
+        {note.title}
+      </h2>
+
+      <div className="mt-auto flex items-end justify-between gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          {note.tags.map((tag) => (
+            <NoteTag key={tag.name} name={tag.name} color={tag.color} />
+          ))}
+        </div>
+
+        <time
+          dateTime={note.createdAt}
+          className="text-muted-foreground shrink-0 text-xs"
+        >
+          {note.createdAt}
+        </time>
+      </div>
+    </Link>
+  );
+};
+
+type NoteCardListProps = {
+  notes: NoteListItem[];
+};
+
+/**
+ * 노트 카드 그리드 컴포넌트
+ * - 2컬럼 그리드 레이아웃
+ * - 데이터 없을 경우 빈 상태 메시지 렌더링
+ * - 필터링/정렬/페이지네이션은 호출 측에서 처리 후 전달
+ *
+ * @param notes 렌더링할 노트 배열 (최종 가공된 데이터)
+ */
+export const NoteCardList = ({ notes }: NoteCardListProps) => {
+  if (notes.length === 0) {
+    return (
+      <div className="text-muted-foreground flex flex-1 items-center justify-center py-20 text-sm">
+        노트가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {notes.map((note) => (
+        <NoteCard key={note.id} note={note} />
+      ))}
+    </div>
+  );
+};

--- a/features/note/components/NoteCardList.tsx
+++ b/features/note/components/NoteCardList.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { NoteTag } from "@/shared/components/NoteTag";
 import type { NoteListItem } from "@/shared/types/note";
 
+import { toISODate } from "../lib/toISODate";
+
 type NoteCardProps = {
   note: NoteListItem;
 };
@@ -33,7 +35,7 @@ const NoteCard = ({ note }: NoteCardProps) => {
         </div>
 
         <time
-          dateTime={note.createdAt}
+          dateTime={toISODate(note.createdAt)}
           className="text-muted-foreground shrink-0 text-xs"
         >
           {note.createdAt}

--- a/features/note/components/NoteCardList.tsx
+++ b/features/note/components/NoteCardList.tsx
@@ -29,8 +29,12 @@ const NoteCard = ({ note }: NoteCardProps) => {
 
       <div className="mt-auto flex items-end justify-between gap-2">
         <div className="flex flex-wrap gap-1.5">
-          {note.tags.map((tag) => (
-            <NoteTag key={tag.name} name={tag.name} color={tag.color} />
+          {note.tags.map((tag, idx) => (
+            <NoteTag
+              key={`${tag.name}-${tag.color}-${idx}`}
+              name={tag.name}
+              color={tag.color}
+            />
           ))}
         </div>
 

--- a/features/note/lib/getNotes.ts
+++ b/features/note/lib/getNotes.ts
@@ -1,0 +1,38 @@
+import type { Category, CategorySortValue } from "@/shared/constants/category";
+import notesData from "@/shared/mocks/notes.json";
+import type { NoteListItem } from "@/shared/types/note";
+
+import { paginateNotes } from "./paginateNotes";
+
+type GetNotesParams = {
+  category: Category;
+  sort: CategorySortValue;
+  page: number;
+};
+
+type GetNotesResult = {
+  notes: NoteListItem[];
+  totalPages: number;
+};
+
+/**
+ * 노트 목록 조회
+ * - 현재: mock JSON에서 필터링·정렬·페이지네이션 처리
+ * - DB 전환 시 이 함수 내부만 교체하면 됨
+ *   ex) supabase.from('notes').select(...).eq(...).order(...).range(...)
+ *
+ * @param params.category 카테고리 필터 ("all"이면 전체)
+ * @param params.sort 정렬 기준
+ * @param params.page 현재 페이지 번호 (1-based)
+ * @returns 페이지에 해당하는 노트 목록과 전체 페이지 수
+ */
+export const getNotes = async ({
+  category,
+  sort,
+  page,
+}: GetNotesParams): Promise<GetNotesResult> => {
+  const notes = notesData.notes as NoteListItem[];
+  const { paginated, totalPages } = paginateNotes({ notes, category, sort, page });
+
+  return { notes: paginated, totalPages };
+};

--- a/features/note/lib/paginateNotes.ts
+++ b/features/note/lib/paginateNotes.ts
@@ -1,0 +1,50 @@
+import type { Category, CategorySortValue } from "@/shared/constants/category";
+import { NOTES_PER_PAGE } from "@/shared/constants/pagination";
+import type { NoteListItem } from "@/shared/types/note";
+
+import { sortNotes } from "./sortNotes";
+
+type PaginateNotesOptions = {
+  notes: NoteListItem[];
+  category: Category;
+  sort: CategorySortValue;
+  page: number;
+};
+
+type PaginateNotesResult = {
+  paginated: NoteListItem[];
+  totalPages: number;
+};
+
+/**
+ * 노트 목록 필터링, 정렬, 페이지네이션 유틸
+ * - category가 "all"이면 전체, 아니면 해당 카테고리만 필터링
+ * - sortNotes로 정렬 후 page 기준으로 슬라이싱
+ * - totalPages는 최소 1 보장
+ *
+ * @param options.notes 전체 노트 배열
+ * @param options.category 선택된 카테고리
+ * @param options.sort 정렬 기준
+ * @param options.page 현재 페이지 번호 (1-based)
+ * @returns 페이지에 해당하는 노트 배열과 전체 페이지 수
+ */
+export const paginateNotes = ({
+  notes,
+  category,
+  sort,
+  page,
+}: PaginateNotesOptions): PaginateNotesResult => {
+  // category가 "all"이면 전체 노트, 아니면 해당 카테고리만 필터링
+  const filtered =
+    category === "all"
+      ? notes
+      : notes.filter((note) => note.category === category);
+
+  const sorted = sortNotes(filtered, sort);
+  const totalPages = Math.max(1, Math.ceil(sorted.length / NOTES_PER_PAGE));
+
+  const startIndex = (page - 1) * NOTES_PER_PAGE;
+  const paginated = sorted.slice(startIndex, startIndex + NOTES_PER_PAGE);
+
+  return { paginated, totalPages };
+};

--- a/features/note/lib/sortNotes.ts
+++ b/features/note/lib/sortNotes.ts
@@ -1,0 +1,23 @@
+import type { CategorySortValue } from "@/shared/constants/category";
+import type { NoteListItem } from "@/shared/types/note";
+
+/**
+ * 노트 정렬 함수
+ * - "alphabetical": 제목 가나다 순
+ * - "oldest": 생성일 오래된 순
+ * - "newest": 생성일 최신 순 (기본)
+ *
+ * @param notes 정렬할 노트 배열
+ * @param sort 정렬 기준
+ * @returns 정렬된 노트 배열
+ */
+export const sortNotes = (
+  notes: NoteListItem[],
+  sort: CategorySortValue,
+): NoteListItem[] => {
+  return [...notes].sort((a, b) => {
+    if (sort === "alphabetical") return a.title.localeCompare(b.title, "ko");
+    if (sort === "oldest") return a.createdAt.localeCompare(b.createdAt);
+    return b.createdAt.localeCompare(a.createdAt);
+  });
+};

--- a/features/note/lib/toISODate.ts
+++ b/features/note/lib/toISODate.ts
@@ -1,0 +1,30 @@
+/**
+ * 날짜 문자열(YYYY.MM.DD)을 ISO 형식(YYYY-MM-DD)으로 변환하는 헬퍼 함수
+ * - 입력 형식 검증: YYYY.MM.DD 형식이 아니거나 유효하지 않은 날짜는 오류 발생
+ * - ISO 변환: Date 객체를 사용하여 ISO 형식으로 변환 (시간 정보 제거)
+ *
+ * @param dateStr 변환할 날짜 문자열 (예: "2024.01.30")
+ * @returns ISO 형식의 날짜 문자열 (예: "2024-01-30")
+ * @throws {Error} 입력이 유효한 날짜 형식이 아닐 경우
+ */
+export const toISODate = (dateStr: string): string => {
+  // 정규식으로 형식 검증 먼저
+  const isoMatch = dateStr.match(/^(\d{4})\.(\d{2})\.(\d{2})$/);
+  if (!isoMatch) {
+    throw new Error("YYYY.MM.DD 형식이 아닙니다");
+  }
+
+  const [, year, month, day] = isoMatch;
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+
+  if (
+    isNaN(date.getTime()) ||
+    date.getFullYear() !== Number(year) ||
+    date.getMonth() + 1 !== Number(month) ||
+    date.getDate() !== Number(day)
+  ) {
+    throw new Error("유효하지 않은 날짜입니다");
+  }
+
+  return `${year}-${month}-${day}`;
+};

--- a/shared/components/NoteTag.tsx
+++ b/shared/components/NoteTag.tsx
@@ -1,0 +1,28 @@
+import type { TagColor } from "@/shared/constants/tag-colors";
+
+type NoteTagProps = {
+  name: string;
+  color: TagColor;
+};
+
+/**
+ * 노트 태그 뱃지 컴포넌트
+ * - CSS 변수 기반 색상 시스템으로 라이트/다크 테마 자동 대응
+ * - color prop은 TAG_COLOR_NAMES 중 하나여야 함
+ *
+ * @param name 태그 이름 (예: "react", "typescript")
+ * @param color 태그 색상 (예: "blue", "green", "red")
+ */
+export const NoteTag = ({ name, color }: NoteTagProps) => {
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+      style={{
+        backgroundColor: `var(--tag-${color}-bg)`,
+        color: `var(--tag-${color}-text)`,
+      }}
+    >
+      #{name}
+    </span>
+  );
+};

--- a/shared/components/Pagination.tsx
+++ b/shared/components/Pagination.tsx
@@ -37,12 +37,14 @@ const PreviousPageButton = ({
   }
 
   return (
-    <span
-      aria-disabled="true"
+    <button
+      type="button"
+      disabled
+      aria-label="이전 페이지 (비활성화)"
       className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg"
     >
       <ChevronIcon size={12} className="text-muted-foreground rotate-90" />
-    </span>
+    </button>
   );
 };
 
@@ -78,12 +80,14 @@ const NextPageButton = ({
   }
 
   return (
-    <span
-      aria-disabled="true"
+    <button
+      type="button"
+      disabled
+      aria-label="다음 페이지 (비활성화)"
       className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg"
     >
       <ChevronIcon size={12} className="text-muted-foreground -rotate-90" />
-    </span>
+    </button>
   );
 };
 

--- a/shared/components/Pagination.tsx
+++ b/shared/components/Pagination.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+import { cn } from "@/shared/lib/cn";
+
+import { buildPageRange } from "../lib/buildPageRange";
+import { ChevronIcon } from "./Icons";
+
+type PreviousPageButtonProps = {
+  currentPage: number;
+  buildHref: (page: number) => string;
+};
+
+/**
+ * 이전 페이지 버튼 컴포넌트
+ * - currentPage가 1보다 크면 활성화된 링크로 렌더링, 그렇지 않으면 비활성화된 상태로 렌더링
+ *
+ * @param currentPage 현재 페이지 번호
+ * @param buildHref 페이지 번호를 받아 해당 페이지로 이동하는 URL을 반환하는 함수
+ */
+const PreviousPageButton = ({
+  currentPage,
+  buildHref,
+}: PreviousPageButtonProps) => {
+  if (currentPage > 1) {
+    return (
+      <Link
+        href={buildHref(currentPage - 1)}
+        aria-label="이전 페이지"
+        className="hover:bg-secondary flex h-8 w-8 items-center justify-center rounded-lg transition-colors"
+      >
+        <ChevronIcon size={12} className="text-foreground rotate-90" />
+      </Link>
+    );
+  }
+
+  return (
+    <span
+      aria-disabled
+      className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg"
+    >
+      <ChevronIcon size={12} className="text-muted-foreground rotate-90" />
+    </span>
+  );
+};
+
+type NextPageButtonProps = {
+  currentPage: number;
+  totalPages: number;
+  buildHref: (page: number) => string;
+};
+
+/**
+ * 다음 페이지 버튼 컴포넌트
+ * - currentPage가 totalPages보다 작으면 활성화된 링크로 렌더링, 그렇지 않으면 비활성화된 상태로 렌더링
+ *
+ * @param currentPage 현재 페이지 번호
+ * @param totalPages 전체 페이지 수
+ * @param buildHref 페이지 번호를 받아 해당 페이지로 이동하는 URL을 반환하는 함수
+ */
+const NextPageButton = ({
+  currentPage,
+  totalPages,
+  buildHref,
+}: NextPageButtonProps) => {
+  if (currentPage < totalPages) {
+    return (
+      <Link
+        href={buildHref(currentPage + 1)}
+        aria-label="다음 페이지"
+        className="hover:bg-secondary flex h-8 w-8 items-center justify-center rounded-lg transition-colors"
+      >
+        <ChevronIcon size={12} className="text-foreground -rotate-90" />
+      </Link>
+    );
+  }
+
+  return (
+    <span
+      aria-disabled
+      className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg"
+    >
+      <ChevronIcon size={12} className="text-muted-foreground -rotate-90" />
+    </span>
+  );
+};
+
+type EllipsisProps = {
+  idx: number;
+};
+
+/**
+ * 페이지네이션에서 페이지 번호 사이에 표시되는 생략 부호 컴포넌트
+ *
+ * @param idx 페이지 번호 목록에서의 인덱스 (key로 사용)
+ */
+const Ellipsis = ({ idx }: EllipsisProps) => {
+  return (
+    <span
+      key={`ellipsis-${idx}`}
+      className="text-muted-foreground flex h-8 w-8 items-center justify-center text-sm"
+    >
+      ...
+    </span>
+  );
+};
+
+type PageNumberProps = {
+  item: number;
+  buildHref: (page: number) => string;
+  isActive: boolean;
+};
+
+/**
+ * 페이지 번호 버튼 컴포넌트
+ * - item이 currentPage와 같으면 활성화된 스타일로 렌더링, 그렇지 않으면 일반 스타일로 렌더링
+ *
+ * @param item 페이지 번호
+ * @param buildHref 페이지 번호를 받아 해당 페이지로 이동하는 URL을 반환하는 함수
+ * @param isActive 현재 페이지인지 여부
+ */
+const PageNumber = ({ item, buildHref, isActive }: PageNumberProps) => {
+  return (
+    <Link
+      key={item}
+      href={buildHref(item)}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium transition-colors",
+        isActive
+          ? "bg-primary text-white"
+          : "text-foreground hover:bg-secondary",
+      )}
+    >
+      {item}
+    </Link>
+  );
+};
+
+type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  basePath: string;
+};
+
+/**
+ * 페이지네이션 공통 컴포넌트
+ *
+ * - path 파라미터 기반 페이지 이동 (`basePath/[page]`)
+ * - searchParams(category, sort) 유지
+ * - 표시 형태: < 1 2 3 ... 12 >
+ */
+export const Pagination = ({
+  currentPage,
+  totalPages,
+  basePath,
+}: PaginationProps) => {
+  const searchParams = useSearchParams();
+  if (totalPages <= 1) return null;
+
+  /**
+   * 특정 페이지로의 링크 URL 생성
+   * - 현재 searchParams(category, sort)를 유지
+   */
+  const buildHref = (page: number): string => {
+    const params = new URLSearchParams(searchParams.toString());
+    const query = params.toString();
+    return query ? `${basePath}/${page}?${query}` : `${basePath}/${page}`;
+  };
+
+  const pageRange = buildPageRange(currentPage, totalPages);
+
+  return (
+    <nav
+      aria-label="페이지네이션"
+      className="font-display flex items-center justify-center gap-1"
+    >
+      <PreviousPageButton currentPage={currentPage} buildHref={buildHref} />
+
+      {pageRange.map((item, idx) => {
+        if (item === "...") {
+          return <Ellipsis key={`ellipsis-${idx}`} idx={idx} />;
+        }
+
+        const isActive = item === currentPage;
+
+        return (
+          <PageNumber
+            key={item}
+            item={item}
+            buildHref={buildHref}
+            isActive={isActive}
+          />
+        );
+      })}
+
+      <NextPageButton
+        currentPage={currentPage}
+        totalPages={totalPages}
+        buildHref={buildHref}
+      />
+    </nav>
+  );
+};

--- a/shared/components/Pagination.tsx
+++ b/shared/components/Pagination.tsx
@@ -38,7 +38,7 @@ const PreviousPageButton = ({
 
   return (
     <span
-      aria-disabled
+      aria-disabled="true"
       className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg"
     >
       <ChevronIcon size={12} className="text-muted-foreground rotate-90" />
@@ -79,7 +79,7 @@ const NextPageButton = ({
 
   return (
     <span
-      aria-disabled
+      aria-disabled="true"
       className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg"
     >
       <ChevronIcon size={12} className="text-muted-foreground -rotate-90" />
@@ -87,21 +87,12 @@ const NextPageButton = ({
   );
 };
 
-type EllipsisProps = {
-  idx: number;
-};
-
 /**
  * 페이지네이션에서 페이지 번호 사이에 표시되는 생략 부호 컴포넌트
- *
- * @param idx 페이지 번호 목록에서의 인덱스 (key로 사용)
  */
-const Ellipsis = ({ idx }: EllipsisProps) => {
+const Ellipsis = () => {
   return (
-    <span
-      key={`ellipsis-${idx}`}
-      className="text-muted-foreground flex h-8 w-8 items-center justify-center text-sm"
-    >
+    <span className="text-muted-foreground flex h-8 w-8 items-center justify-center text-sm">
       ...
     </span>
   );
@@ -124,7 +115,6 @@ type PageNumberProps = {
 const PageNumber = ({ item, buildHref, isActive }: PageNumberProps) => {
   return (
     <Link
-      key={item}
       href={buildHref(item)}
       aria-current={isActive ? "page" : undefined}
       className={cn(
@@ -181,7 +171,7 @@ export const Pagination = ({
 
       {pageRange.map((item, idx) => {
         if (item === "...") {
-          return <Ellipsis key={`ellipsis-${idx}`} idx={idx} />;
+          return <Ellipsis key={`ellipsis-${idx}`} />;
         }
 
         const isActive = item === currentPage;

--- a/shared/components/Pagination.tsx
+++ b/shared/components/Pagination.tsx
@@ -9,25 +9,20 @@ import { buildPageRange } from "../lib/buildPageRange";
 import { ChevronIcon } from "./Icons";
 
 type PreviousPageButtonProps = {
-  currentPage: number;
-  buildHref: (page: number) => string;
+  prevHref?: string;
 };
 
 /**
  * 이전 페이지 버튼 컴포넌트
- * - currentPage가 1보다 크면 활성화된 링크로 렌더링, 그렇지 않으면 비활성화된 상태로 렌더링
+ * - prevHref가 있으면 활성화된 링크로 렌더링, 없으면 비활성화된 상태로 렌더링
  *
- * @param currentPage 현재 페이지 번호
- * @param buildHref 페이지 번호를 받아 해당 페이지로 이동하는 URL을 반환하는 함수
+ * @param prevHref 이전 페이지 URL (없으면 비활성화)
  */
-const PreviousPageButton = ({
-  currentPage,
-  buildHref,
-}: PreviousPageButtonProps) => {
-  if (currentPage > 1) {
+const PreviousPageButton = ({ prevHref }: PreviousPageButtonProps) => {
+  if (prevHref) {
     return (
       <Link
-        href={buildHref(currentPage - 1)}
+        href={prevHref}
         aria-label="이전 페이지"
         className="hover:bg-secondary flex h-8 w-8 items-center justify-center rounded-lg transition-colors"
       >
@@ -49,28 +44,20 @@ const PreviousPageButton = ({
 };
 
 type NextPageButtonProps = {
-  currentPage: number;
-  totalPages: number;
-  buildHref: (page: number) => string;
+  nextHref?: string;
 };
 
 /**
  * 다음 페이지 버튼 컴포넌트
- * - currentPage가 totalPages보다 작으면 활성화된 링크로 렌더링, 그렇지 않으면 비활성화된 상태로 렌더링
+ * - nextHref가 있으면 활성화된 링크로 렌더링, 없으면 비활성화된 상태로 렌더링
  *
- * @param currentPage 현재 페이지 번호
- * @param totalPages 전체 페이지 수
- * @param buildHref 페이지 번호를 받아 해당 페이지로 이동하는 URL을 반환하는 함수
+ * @param nextHref 다음 페이지 URL (없으면 비활성화)
  */
-const NextPageButton = ({
-  currentPage,
-  totalPages,
-  buildHref,
-}: NextPageButtonProps) => {
-  if (currentPage < totalPages) {
+const NextPageButton = ({ nextHref }: NextPageButtonProps) => {
+  if (nextHref) {
     return (
       <Link
-        href={buildHref(currentPage + 1)}
+        href={nextHref}
         aria-label="다음 페이지"
         className="hover:bg-secondary flex h-8 w-8 items-center justify-center rounded-lg transition-colors"
       >
@@ -104,22 +91,22 @@ const Ellipsis = () => {
 
 type PageNumberProps = {
   item: number;
-  buildHref: (page: number) => string;
+  pageHref: string;
   isActive: boolean;
 };
 
 /**
  * 페이지 번호 버튼 컴포넌트
- * - item이 currentPage와 같으면 활성화된 스타일로 렌더링, 그렇지 않으면 일반 스타일로 렌더링
+ * - isActive이면 활성화된 스타일로 렌더링, 그렇지 않으면 일반 스타일로 렌더링
  *
  * @param item 페이지 번호
- * @param buildHref 페이지 번호를 받아 해당 페이지로 이동하는 URL을 반환하는 함수
+ * @param pageHref 해당 페이지 URL
  * @param isActive 현재 페이지인지 여부
  */
-const PageNumber = ({ item, buildHref, isActive }: PageNumberProps) => {
+const PageNumber = ({ item, pageHref, isActive }: PageNumberProps) => {
   return (
     <Link
-      href={buildHref(item)}
+      href={pageHref}
       aria-current={isActive ? "page" : undefined}
       className={cn(
         "flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium transition-colors",
@@ -154,15 +141,9 @@ export const Pagination = ({
   const searchParams = useSearchParams();
   if (totalPages <= 1) return null;
 
-  /**
-   * 특정 페이지로의 링크 URL 생성
-   * - 현재 searchParams(category, sort)를 유지
-   */
-  const buildHref = (page: number): string => {
-    const params = new URLSearchParams(searchParams.toString());
-    const query = params.toString();
-    return query ? `${basePath}/${page}?${query}` : `${basePath}/${page}`;
-  };
+  const query = searchParams.toString();
+  const hrefBuilder = (page: number) =>
+    query ? `${basePath}/${page}?${query}` : `${basePath}/${page}`;
 
   const pageRange = buildPageRange(currentPage, totalPages);
 
@@ -171,7 +152,9 @@ export const Pagination = ({
       aria-label="페이지네이션"
       className="font-display flex items-center justify-center gap-1"
     >
-      <PreviousPageButton currentPage={currentPage} buildHref={buildHref} />
+      <PreviousPageButton
+        prevHref={currentPage > 1 ? hrefBuilder(currentPage - 1) : undefined}
+      />
 
       {pageRange.map((item, idx) => {
         if (item === "...") {
@@ -184,16 +167,14 @@ export const Pagination = ({
           <PageNumber
             key={item}
             item={item}
-            buildHref={buildHref}
+            pageHref={hrefBuilder(item)}
             isActive={isActive}
           />
         );
       })}
 
       <NextPageButton
-        currentPage={currentPage}
-        totalPages={totalPages}
-        buildHref={buildHref}
+        nextHref={currentPage < totalPages ? hrefBuilder(currentPage + 1) : undefined}
       />
     </nav>
   );

--- a/shared/components/__tests__/NoteTag.test.tsx
+++ b/shared/components/__tests__/NoteTag.test.tsx
@@ -30,7 +30,8 @@ describe("NoteTag", () => {
 
     it("color(텍스트)에 color에 해당하는 CSS 변수가 적용된다", () => {
       const { container } = render(<NoteTag name="test" color="purple" />);
-      const span = container.querySelector("span")!;
+      const span = container.querySelector("span");
+      expect(span).toBeInTheDocument();
 
       expect(span).toHaveStyle({ color: "var(--tag-purple-text)" });
     });

--- a/shared/components/__tests__/NoteTag.test.tsx
+++ b/shared/components/__tests__/NoteTag.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TAG_COLOR_NAMES } from "@/shared/constants/tag-colors";
+
+import { NoteTag } from "../NoteTag";
+
+describe("NoteTag", () => {
+  describe("렌더링", () => {
+    it("태그 이름 앞에 # 기호를 붙여 렌더링한다", () => {
+      render(<NoteTag name="react" color="blue" />);
+
+      expect(screen.getByText("#react")).toBeInTheDocument();
+    });
+
+    it("span 엘리먼트로 렌더링된다", () => {
+      const { container } = render(<NoteTag name="typescript" color="blue" />);
+
+      expect(container.querySelector("span")).toBeInTheDocument();
+    });
+  });
+
+  describe("색상 CSS 변수", () => {
+    it("backgroundColor에 color에 해당하는 CSS 변수가 적용된다", () => {
+      const { container } = render(<NoteTag name="test" color="green" />);
+      const span = container.querySelector("span")!;
+
+      expect(span).toHaveStyle({ backgroundColor: "var(--tag-green-bg)" });
+    });
+
+    it("color(텍스트)에 color에 해당하는 CSS 변수가 적용된다", () => {
+      const { container } = render(<NoteTag name="test" color="purple" />);
+      const span = container.querySelector("span")!;
+
+      expect(span).toHaveStyle({ color: "var(--tag-purple-text)" });
+    });
+
+    it.each(TAG_COLOR_NAMES)(
+      "color=%s 일 때 올바른 CSS 변수를 사용한다",
+      (color) => {
+        const { container } = render(<NoteTag name="tag" color={color} />);
+        const span = container.querySelector("span")!;
+
+        expect(span).toHaveStyle({
+          backgroundColor: `var(--tag-${color}-bg)`,
+          color: `var(--tag-${color}-text)`,
+        });
+      },
+    );
+  });
+});

--- a/shared/components/__tests__/Pagination.test.tsx
+++ b/shared/components/__tests__/Pagination.test.tsx
@@ -81,17 +81,18 @@ describe("Pagination", () => {
   });
 
   describe("이전/다음 버튼", () => {
-    it("currentPage=1이면 이전 버튼이 비활성화 span으로 렌더링된다", () => {
-      const { container } = render(
+    it("currentPage=1이면 이전 버튼이 비활성화 button으로 렌더링된다", () => {
+      render(
         <Pagination currentPage={1} totalPages={5} basePath="/notes" />,
       );
 
-      // 활성 링크 없이 aria-disabled span으로 렌더링
+      // 활성 링크 없이 disabled button으로 렌더링
       expect(
         screen.queryByRole("link", { name: "이전 페이지" }),
       ).not.toBeInTheDocument();
-      const disabledSpan = container.querySelector("[aria-disabled='true']");
-      expect(disabledSpan).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "이전 페이지 (비활성화)" }),
+      ).toBeDisabled();
     });
 
     it("currentPage < totalPages이면 다음 버튼이 활성 링크로 렌더링된다", () => {
@@ -111,12 +112,15 @@ describe("Pagination", () => {
       );
     });
 
-    it("currentPage=totalPages이면 다음 버튼이 비활성화 span으로 렌더링된다", () => {
+    it("currentPage=totalPages이면 다음 버튼이 비활성화 button으로 렌더링된다", () => {
       render(<Pagination currentPage={5} totalPages={5} basePath="/notes" />);
 
       expect(
         screen.queryByRole("link", { name: "다음 페이지" }),
       ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "다음 페이지 (비활성화)" }),
+      ).toBeDisabled();
     });
   });
 

--- a/shared/components/__tests__/Pagination.test.tsx
+++ b/shared/components/__tests__/Pagination.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Pagination } from "../Pagination";
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("../Icons", () => ({
+  ChevronIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="chevron-icon" className={className} />
+  ),
+}));
+
+describe("Pagination", () => {
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams();
+  });
+
+  describe("렌더링 조건", () => {
+    it("totalPages가 1이면 렌더링하지 않는다", () => {
+      const { container } = render(
+        <Pagination currentPage={1} totalPages={1} basePath="/notes" />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("totalPages가 2 이상이면 nav를 렌더링한다", () => {
+      render(<Pagination currentPage={1} totalPages={5} basePath="/notes" />);
+
+      expect(screen.getByRole("navigation", { name: "페이지네이션" })).toBeInTheDocument();
+    });
+  });
+
+  describe("페이지 번호 링크", () => {
+    it("페이지 번호 링크의 href는 basePath/page 형태다", () => {
+      render(<Pagination currentPage={1} totalPages={3} basePath="/notes" />);
+
+      // totalPages=3이면 모두 표시됨
+      expect(screen.getByRole("link", { name: "2" })).toHaveAttribute(
+        "href",
+        "/notes/2",
+      );
+      expect(screen.getByRole("link", { name: "3" })).toHaveAttribute(
+        "href",
+        "/notes/3",
+      );
+    });
+
+    it("searchParams가 있으면 href에 query string을 유지한다", () => {
+      mockSearchParams = new URLSearchParams("category=frontend&sort=newest");
+      render(<Pagination currentPage={1} totalPages={3} basePath="/notes" />);
+
+      const link = screen.getByRole("link", { name: "2" });
+      expect(link.getAttribute("href")).toContain("category=frontend");
+      expect(link.getAttribute("href")).toContain("sort=newest");
+    });
+
+    it("현재 페이지 링크는 aria-current=page를 가진다", () => {
+      render(<Pagination currentPage={2} totalPages={3} basePath="/notes" />);
+
+      expect(screen.getByRole("link", { name: "2" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    });
+
+    it("현재 페이지가 아닌 링크는 aria-current가 없다", () => {
+      render(<Pagination currentPage={2} totalPages={3} basePath="/notes" />);
+
+      expect(screen.getByRole("link", { name: "1" })).not.toHaveAttribute(
+        "aria-current",
+      );
+    });
+  });
+
+  describe("이전/다음 버튼", () => {
+    it("currentPage=1이면 이전 버튼이 비활성화 span으로 렌더링된다", () => {
+      const { container } = render(
+        <Pagination currentPage={1} totalPages={5} basePath="/notes" />,
+      );
+
+      // 활성 링크 없이 aria-disabled span으로 렌더링
+      expect(screen.queryByRole("link", { name: "이전 페이지" })).not.toBeInTheDocument();
+      expect(container.querySelector("[aria-disabled]")).toBeInTheDocument();
+    });
+
+    it("currentPage < totalPages이면 다음 버튼이 활성 링크로 렌더링된다", () => {
+      render(<Pagination currentPage={1} totalPages={5} basePath="/notes" />);
+
+      expect(
+        screen.getByRole("link", { name: "다음 페이지" }),
+      ).toBeInTheDocument();
+    });
+
+    it("다음 페이지 링크 href는 currentPage+1이다", () => {
+      render(<Pagination currentPage={2} totalPages={5} basePath="/notes" />);
+
+      expect(screen.getByRole("link", { name: "다음 페이지" })).toHaveAttribute(
+        "href",
+        "/notes/3",
+      );
+    });
+
+    it("currentPage=totalPages이면 다음 버튼이 비활성화 span으로 렌더링된다", () => {
+      render(<Pagination currentPage={5} totalPages={5} basePath="/notes" />);
+
+      expect(
+        screen.queryByRole("link", { name: "다음 페이지" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ellipsis", () => {
+    it("페이지가 많으면 ellipsis(...)가 렌더링된다", () => {
+      render(<Pagination currentPage={5} totalPages={10} basePath="/notes" />);
+
+      const ellipses = screen.getAllByText("...");
+      expect(ellipses.length).toBeGreaterThan(0);
+    });
+
+    it("totalPages<=5이면 ellipsis가 없다", () => {
+      render(<Pagination currentPage={3} totalPages={5} basePath="/notes" />);
+
+      expect(screen.queryByText("...")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/shared/components/__tests__/Pagination.test.tsx
+++ b/shared/components/__tests__/Pagination.test.tsx
@@ -32,7 +32,9 @@ describe("Pagination", () => {
     it("totalPages가 2 이상이면 nav를 렌더링한다", () => {
       render(<Pagination currentPage={1} totalPages={5} basePath="/notes" />);
 
-      expect(screen.getByRole("navigation", { name: "페이지네이션" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("navigation", { name: "페이지네이션" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -85,8 +87,11 @@ describe("Pagination", () => {
       );
 
       // 활성 링크 없이 aria-disabled span으로 렌더링
-      expect(screen.queryByRole("link", { name: "이전 페이지" })).not.toBeInTheDocument();
-      expect(container.querySelector("[aria-disabled]")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "이전 페이지" }),
+      ).not.toBeInTheDocument();
+      const disabledSpan = container.querySelector("[aria-disabled='true']");
+      expect(disabledSpan).toBeInTheDocument();
     });
 
     it("currentPage < totalPages이면 다음 버튼이 활성 링크로 렌더링된다", () => {

--- a/shared/constants/pagination.ts
+++ b/shared/constants/pagination.ts
@@ -1,0 +1,5 @@
+// 페이지당 표시할 노트 수
+export const NOTES_PER_PAGE = 10;
+
+// 페이지네이션에서 표시할 최대 페이지 버튼 수 (양쪽 ellipsis 포함)
+export const MAX_VISIBLE_PAGES = 5;

--- a/shared/lib/__tests__/buildPageRange.test.ts
+++ b/shared/lib/__tests__/buildPageRange.test.ts
@@ -78,12 +78,13 @@ describe("buildPageRange", () => {
 
     it("연속된 숫자 사이에 ellipsis가 삽입되지 않는다", () => {
       const result = buildPageRange(1, 10);
-      // 숫자인 요소만 추출해서 연속 여부 확인
-      const numbers = result.filter((item): item is number => item !== "...");
-      for (let i = 1; i < numbers.length; i++) {
-        // ellipsis가 없는 숫자는 연속이어야 함
-        // (ellipsis가 있는 위치를 기준으로만 판단 가능하므로 단순 검증)
-        expect(numbers[i]).toBeGreaterThan(numbers[i - 1]);
+      // ellipsis 앞뒤 숫자가 2 이상 차이나는지 확인
+      for (let i = 0; i < result.length; i++) {
+        if (result[i] === "...") {
+          const prev = result[i - 1] as number;
+          const next = result[i + 1] as number;
+          expect(next - prev).toBeGreaterThan(1);
+        }
       }
     });
   });

--- a/shared/lib/__tests__/buildPageRange.test.ts
+++ b/shared/lib/__tests__/buildPageRange.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_VISIBLE_PAGES } from "@/shared/constants/pagination";
+
+import { buildPageRange } from "../buildPageRange";
+
+describe("buildPageRange", () => {
+  describe(`totalPages <= ${MAX_VISIBLE_PAGES}인 경우`, () => {
+    it("1페이지면 [1]을 반환한다", () => {
+      expect(buildPageRange(1, 1)).toEqual([1]);
+    });
+
+    it(`totalPages가 ${MAX_VISIBLE_PAGES}이면 1~${MAX_VISIBLE_PAGES} 전부 반환한다`, () => {
+      const result = buildPageRange(3, MAX_VISIBLE_PAGES);
+      expect(result).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe("ellipsis 없음 (currentPage가 앞쪽)", () => {
+    it("currentPage=1, totalPages=10 → [1, 2, ..., 10]", () => {
+      expect(buildPageRange(1, 10)).toEqual([1, 2, "...", 10]);
+    });
+
+    it("currentPage=2, totalPages=10 → [1, 2, 3, ..., 10]", () => {
+      expect(buildPageRange(2, 10)).toEqual([1, 2, 3, "...", 10]);
+    });
+
+    it("currentPage=3, totalPages=10 → [1, 2, 3, 4, ..., 10]", () => {
+      expect(buildPageRange(3, 10)).toEqual([1, 2, 3, 4, "...", 10]);
+    });
+  });
+
+  describe("양쪽 ellipsis (currentPage가 중간)", () => {
+    it("currentPage=5, totalPages=10 → [1, ..., 4, 5, 6, ..., 10]", () => {
+      expect(buildPageRange(5, 10)).toEqual([1, "...", 4, 5, 6, "...", 10]);
+    });
+
+    it("currentPage=6, totalPages=10 → [1, ..., 5, 6, 7, ..., 10]", () => {
+      expect(buildPageRange(6, 10)).toEqual([1, "...", 5, 6, 7, "...", 10]);
+    });
+  });
+
+  describe("ellipsis 없음 (currentPage가 뒤쪽)", () => {
+    it("currentPage=10, totalPages=10 → [1, ..., 9, 10]", () => {
+      expect(buildPageRange(10, 10)).toEqual([1, "...", 9, 10]);
+    });
+
+    it("currentPage=9, totalPages=10 → [1, ..., 8, 9, 10]", () => {
+      expect(buildPageRange(9, 10)).toEqual([1, "...", 8, 9, 10]);
+    });
+
+    it("currentPage=8, totalPages=10 → [1, ..., 7, 8, 9, 10]", () => {
+      expect(buildPageRange(8, 10)).toEqual([1, "...", 7, 8, 9, 10]);
+    });
+  });
+
+  describe("반환값 공통 규칙", () => {
+    it("항상 첫 번째 요소가 1이다", () => {
+      for (let page = 1; page <= 12; page++) {
+        const result = buildPageRange(page, 12);
+        expect(result[0]).toBe(1);
+      }
+    });
+
+    it("항상 마지막 요소가 totalPages다", () => {
+      for (let page = 1; page <= 12; page++) {
+        const result = buildPageRange(page, 12);
+        expect(result[result.length - 1]).toBe(12);
+      }
+    });
+
+    it("currentPage가 항상 결과에 포함된다", () => {
+      for (let page = 1; page <= 12; page++) {
+        const result = buildPageRange(page, 12);
+        expect(result).toContain(page);
+      }
+    });
+
+    it("연속된 숫자 사이에 ellipsis가 삽입되지 않는다", () => {
+      const result = buildPageRange(1, 10);
+      // 숫자인 요소만 추출해서 연속 여부 확인
+      const numbers = result.filter((item): item is number => item !== "...");
+      for (let i = 1; i < numbers.length; i++) {
+        // ellipsis가 없는 숫자는 연속이어야 함
+        // (ellipsis가 있는 위치를 기준으로만 판단 가능하므로 단순 검증)
+        expect(numbers[i]).toBeGreaterThan(numbers[i - 1]);
+      }
+    });
+  });
+});

--- a/shared/lib/buildPageRange.ts
+++ b/shared/lib/buildPageRange.ts
@@ -1,0 +1,40 @@
+import { MAX_VISIBLE_PAGES } from "../constants/pagination";
+
+/**
+ * 페이지 번호 범위 계산 유틸
+ * - currentPage 주변 ±2 범위를 기준으로 표시할 페이지 목록 반환
+ * - 항상 첫/마지막 페이지 포함, 필요 시 ellipsis("...") 삽입
+ *
+ * @param currentPage 현재 페이지
+ * @param totalPages 전체 페이지
+ * @returns (number | "...")[] 형태의 페이지 목록
+ */
+export const buildPageRange = (
+  currentPage: number,
+  totalPages: number,
+): (number | "...")[] => {
+  // totalPages가 MAX_VISIBLE_PAGES 이하인 경우 1~totalPages까지 모두 표시
+  if (totalPages <= MAX_VISIBLE_PAGES) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const delta = 1;
+  const rangeStart = Math.max(2, currentPage - delta);
+  const rangeEnd = Math.min(totalPages - 1, currentPage + delta);
+
+  const pages: (number | "...")[] = [1];
+
+  // rangeStart가 2보다 크면 1과 rangeStart 사이에 페이지가 존재
+  // ellipsis 추가
+  if (rangeStart > 2) pages.push("...");
+  for (let i = rangeStart; i <= rangeEnd; i++) {
+    pages.push(i);
+  }
+
+  // rangeEnd가 totalPages - 1보다 작으면 totalPages - 1과 totalPages 사이에 페이지가 존재
+  // ellipsis 추가
+  if (rangeEnd < totalPages - 1) pages.push("...");
+  pages.push(totalPages);
+
+  return pages;
+};

--- a/shared/mocks/notes.json
+++ b/shared/mocks/notes.json
@@ -1,0 +1,274 @@
+{
+  "notes": [
+    {
+      "id": "note-01",
+      "title": "그래프 탐색 알고리즘: BFS와 DFS의 실전 활용",
+      "category": "cs",
+      "tags": [
+        { "name": "Algorithm", "color": "purple" },
+        { "name": "Graph", "color": "teal" },
+        { "name": "Interviews", "color": "pink" }
+      ],
+      "createdAt": "2024.05.08"
+    },
+    {
+      "id": "note-02",
+      "title": "React 렌더링 최적화: memo, useMemo, useCallback 실전 가이드",
+      "category": "frontend",
+      "tags": [
+        { "name": "React", "color": "blue" },
+        { "name": "Performance", "color": "orange" },
+        { "name": "TypeScript", "color": "indigo" }
+      ],
+      "createdAt": "2024.05.10"
+    },
+    {
+      "id": "note-03",
+      "title": "TypeScript Generic 활용 패턴과 고급 타입 시스템",
+      "category": "frontend",
+      "tags": [
+        { "name": "TypeScript", "color": "indigo" },
+        { "name": "Generic", "color": "blue" }
+      ],
+      "createdAt": "2024.05.12"
+    },
+    {
+      "id": "note-04",
+      "title": "Next.js App Router 완전 정복: RSC와 Server Actions",
+      "category": "frontend",
+      "tags": [
+        { "name": "Next.js", "color": "gray" },
+        { "name": "React", "color": "blue" },
+        { "name": "RSC", "color": "teal" }
+      ],
+      "createdAt": "2024.05.14"
+    },
+    {
+      "id": "note-05",
+      "title": "REST API vs GraphQL: 설계 원칙과 트레이드오프",
+      "category": "backend",
+      "tags": [
+        { "name": "REST", "color": "blue" },
+        { "name": "GraphQL", "color": "pink" },
+        { "name": "API", "color": "green" }
+      ],
+      "createdAt": "2024.05.16"
+    },
+    {
+      "id": "note-06",
+      "title": "동적 프로그래밍으로 최적화 문제 해결하기",
+      "category": "cs",
+      "tags": [
+        { "name": "Algorithm", "color": "purple" },
+        { "name": "DP", "color": "indigo" },
+        { "name": "Interviews", "color": "pink" }
+      ],
+      "createdAt": "2024.05.18"
+    },
+    {
+      "id": "note-07",
+      "title": "Docker 컨테이너화 베스트 프랙티스와 멀티스테이지 빌드",
+      "category": "devops",
+      "tags": [
+        { "name": "Docker", "color": "blue" },
+        { "name": "CI/CD", "color": "yellow" }
+      ],
+      "createdAt": "2024.05.20"
+    },
+    {
+      "id": "note-08",
+      "title": "Zustand vs Jotai: 경량 상태관리 라이브러리 비교",
+      "category": "frontend",
+      "tags": [
+        { "name": "Zustand", "color": "purple" },
+        { "name": "React", "color": "blue" },
+        { "name": "State", "color": "teal" }
+      ],
+      "createdAt": "2024.05.22"
+    },
+    {
+      "id": "note-09",
+      "title": "Node.js 이벤트 루프와 비동기 처리 메커니즘",
+      "category": "backend",
+      "tags": [
+        { "name": "Node.js", "color": "green" },
+        { "name": "Async", "color": "orange" },
+        { "name": "JavaScript", "color": "yellow" }
+      ],
+      "createdAt": "2024.05.24"
+    },
+    {
+      "id": "note-10",
+      "title": "JWT vs Session 인증 방식 비교와 보안 고려사항",
+      "category": "backend",
+      "tags": [
+        { "name": "JWT", "color": "orange" },
+        { "name": "Auth", "color": "red" },
+        { "name": "Security", "color": "pink" }
+      ],
+      "createdAt": "2024.05.26"
+    },
+    {
+      "id": "note-11",
+      "title": "해시 테이블 충돌 처리: 체이닝과 오픈 어드레싱",
+      "category": "cs",
+      "tags": [
+        { "name": "HashTable", "color": "teal" },
+        { "name": "DataStructure", "color": "purple" }
+      ],
+      "createdAt": "2024.05.28"
+    },
+    {
+      "id": "note-12",
+      "title": "GitHub Actions CI/CD 파이프라인 구축 완벽 가이드",
+      "category": "devops",
+      "tags": [
+        { "name": "GitHub Actions", "color": "gray" },
+        { "name": "CI/CD", "color": "yellow" },
+        { "name": "Automation", "color": "green" }
+      ],
+      "createdAt": "2024.05.30"
+    },
+    {
+      "id": "note-13",
+      "title": "PostgreSQL 인덱스 최적화와 쿼리 플래닝 전략",
+      "category": "backend",
+      "tags": [
+        { "name": "PostgreSQL", "color": "blue" },
+        { "name": "Database", "color": "indigo" },
+        { "name": "Performance", "color": "orange" }
+      ],
+      "createdAt": "2024.06.01"
+    },
+    {
+      "id": "note-14",
+      "title": "CSS-in-JS vs Tailwind CSS: 스타일링 패러다임 트레이드오프",
+      "category": "frontend",
+      "tags": [
+        { "name": "CSS", "color": "pink" },
+        { "name": "Tailwind", "color": "teal" }
+      ],
+      "createdAt": "2024.06.03"
+    },
+    {
+      "id": "note-15",
+      "title": "트리 자료구조와 B-Tree 인덱스의 관계",
+      "category": "cs",
+      "tags": [
+        { "name": "Tree", "color": "green" },
+        { "name": "DataStructure", "color": "purple" },
+        { "name": "Database", "color": "indigo" }
+      ],
+      "createdAt": "2024.06.05"
+    },
+    {
+      "id": "note-16",
+      "title": "Kubernetes 파드 스케일링과 리소스 관리 전략",
+      "category": "devops",
+      "tags": [
+        { "name": "Kubernetes", "color": "indigo" },
+        { "name": "Docker", "color": "blue" },
+        { "name": "Scaling", "color": "green" }
+      ],
+      "createdAt": "2024.06.07"
+    },
+    {
+      "id": "note-17",
+      "title": "Redis 캐싱 전략: Cache-Aside, Write-Through, Write-Behind",
+      "category": "backend",
+      "tags": [
+        { "name": "Redis", "color": "red" },
+        { "name": "Caching", "color": "orange" },
+        { "name": "Performance", "color": "yellow" }
+      ],
+      "createdAt": "2024.06.09"
+    },
+    {
+      "id": "note-18",
+      "title": "OSI 7계층과 TCP/IP 프로토콜 스택 심화 분석",
+      "category": "cs",
+      "tags": [
+        { "name": "Network", "color": "blue" },
+        { "name": "TCP/IP", "color": "teal" },
+        { "name": "Interviews", "color": "pink" }
+      ],
+      "createdAt": "2024.06.11"
+    },
+    {
+      "id": "note-19",
+      "title": "React Query vs SWR: 서버 상태 관리 전략 비교",
+      "category": "frontend",
+      "tags": [
+        { "name": "React Query", "color": "green" },
+        { "name": "SWR", "color": "blue" },
+        { "name": "DataFetching", "color": "orange" }
+      ],
+      "createdAt": "2024.06.13"
+    },
+    {
+      "id": "note-20",
+      "title": "NestJS 의존성 주입 패턴과 모듈 아키텍처",
+      "category": "backend",
+      "tags": [
+        { "name": "NestJS", "color": "purple" },
+        { "name": "Node.js", "color": "green" },
+        { "name": "Architecture", "color": "indigo" }
+      ],
+      "createdAt": "2024.06.15"
+    },
+    {
+      "id": "note-21",
+      "title": "Nginx 리버스 프록시 설정과 로드 밸런싱 구성",
+      "category": "devops",
+      "tags": [
+        { "name": "Nginx", "color": "green" },
+        { "name": "LoadBalancing", "color": "teal" }
+      ],
+      "createdAt": "2024.06.17"
+    },
+    {
+      "id": "note-22",
+      "title": "메모리 관리와 가비지 컬렉션: V8 엔진 동작 원리",
+      "category": "cs",
+      "tags": [
+        { "name": "Memory", "color": "yellow" },
+        { "name": "JavaScript", "color": "orange" },
+        { "name": "V8", "color": "gray" }
+      ],
+      "createdAt": "2024.06.19"
+    },
+    {
+      "id": "note-23",
+      "title": "Vite와 Webpack 번들러 심층 비교: 빌드 성능 분석",
+      "category": "frontend",
+      "tags": [
+        { "name": "Vite", "color": "yellow" },
+        { "name": "Webpack", "color": "orange" },
+        { "name": "Build", "color": "gray" }
+      ],
+      "createdAt": "2024.06.21"
+    },
+    {
+      "id": "note-24",
+      "title": "AWS Lambda 서버리스 함수 최적화와 Cold Start 해결",
+      "category": "devops",
+      "tags": [
+        { "name": "AWS", "color": "orange" },
+        { "name": "Serverless", "color": "yellow" },
+        { "name": "Lambda", "color": "red" }
+      ],
+      "createdAt": "2024.06.23"
+    },
+    {
+      "id": "note-25",
+      "title": "Core Web Vitals 최적화: LCP, FID, CLS 개선 전략",
+      "category": "frontend",
+      "tags": [
+        { "name": "Performance", "color": "orange" },
+        { "name": "SEO", "color": "green" },
+        { "name": "Next.js", "color": "gray" }
+      ],
+      "createdAt": "2024.06.25"
+    }
+  ]
+}

--- a/shared/types/note.ts
+++ b/shared/types/note.ts
@@ -1,0 +1,28 @@
+import type { Category } from "@/shared/constants/category";
+import type { TagColor } from "@/shared/constants/tag-colors";
+
+/**
+ * 노트 목록에서 사용하는 태그 타입
+ * - name: 태그 텍스트
+ * - color: CSS 변수 기반 태그 색상
+ */
+export type NoteTag = {
+  name: string;
+  color: TagColor;
+};
+
+/**
+ * 노트 목록 아이템 타입
+ * - id: 고유 식별자
+ * - title: 노트 제목
+ * - category: 카테고리 (all 제외한 값)
+ * - tags: 연관 태그 목록
+ * - createdAt: 생성일 (YYYY.MM.DD)
+ */
+export type NoteListItem = {
+  id: string;
+  title: string;
+  category: Exclude<Category, "all">;
+  tags: NoteTag[];
+  createdAt: string;
+};


### PR DESCRIPTION
## 🍀 관련 이슈

close #15

<br /><br />

## 🍀 개요

> 이 PR에서 구현하거나 수정한 내용을 한 줄로 요약합니다.

노트 목록 페이지 UI 구현 - path param 기반 페이지네이션, 카테고리 필터, 정렬 적용

<br /><br />

## 🍀 작업 내용

> 변경된 내용을 리스트 형태로 정리합니다.

- `shared/types/note.ts` - NoteListItem, NoteTag 타입 정의
- `shared/constants/pagination.ts` - NOTES_PER_PAGE, MAX_VISIBLE_PAGES 상수 추가
- `shared/mocks/notes.json` - 개발용 mock 노트 데이터 추가
- `shared/lib/buildPageRange.ts` - ellipsis 포함 페이지 범위 계산 유틸
- `shared/components/NoteTag.tsx` - CSS 변수 기반 색상 태그 뱃지 컴포넌트
- `shared/components/Pagination.tsx` - path param 기반 페이지네이션 컴포넌트 (searchParams 유지)
- `features/note/lib/` - sortNotes, paginateNotes, getNotes 비즈니스 로직 (DB 전환 고려한 레이어 분리)
- `features/note/components/NoteCardList.tsx` - 2컬럼 그리드 카드 목록, 빈 상태 처리
- `app/notes/page.tsx` - `/notes` → `/notes/1` 리다이렉트로 변경
- `app/notes/[page]/page.tsx` - 동적 라우팅 기반 노트 목록 페이지 신규 추가
- `app/layout.tsx` - main에 `flex flex-col` 추가로 Pagination 하단 고정 레이아웃 지원

<br /><br />

## 🍀 스크린샷

> UI 변경이 있는 경우 첨부합니다.

<img width="1248" height="813" alt="스크린샷 2026-03-30 오후 9 03 58" src="https://github.com/user-attachments/assets/ed5037c4-ebc1-4903-a25f-a25df728f0bc" />